### PR TITLE
Run unit tests in headless Chrome

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -82,11 +82,13 @@
 				"idle-timeout": 60,
 				"fixSessionCapabilities": "no-detect"
 			},
-			"environments+": [
+			"environments": [
 				{ "browserName": "internet explorer", "version": "11", "os": "WINDOWS", "os_version": [ "8.1", "10" ] },
 				{ "browserName": "edge" },
 				{ "browserName": "firefox", "platform": "WINDOWS" },
+				{ "browserName": "chrome" },
 				{ "browserName": "chrome", "platform": "WINDOWS" },
+				{ "browserName": "node" },
 				{ "browserName": "safari", "version": [ "10.1", "11" ], "platform": "MAC" },
 				{ "browserName": "safari", "version": "12", "os_version": "Mojave" }
 			]

--- a/intern.json
+++ b/intern.json
@@ -2,7 +2,10 @@
 	"basePath": "./",
 	"environments": [
 		{ "browserName": "node" },
-		{ "browserName": "chrome" }
+		{ "browserName": "chrome", "goog:chromeOptions": {
+			"args": ["headless", "disable-gpu", "window-size=1280,1024"]
+		  } 
+		}
 	],
 	"maxConcurrency": 2,
 	"tunnel": "selenium",


### PR DESCRIPTION
At the moment we run our tests locally with headed Chrome which can be a bit invasive. This makes the unit tests run in headless Chrome.