### PR TITLE
Stop menu items nudging in on pages with scroll

### DIFF
--- a/src/widgets/Header.m.css
+++ b/src/widgets/Header.m.css
@@ -17,9 +17,11 @@
 	justify-content: flex-start;
 	align-content: flex-start;
 	align-items: center;
+	padding-left: calc(100vw - 100%);
 }
 
 .menu {
+	margin-right: 20px;
 }
 
 .menuList {


### PR DESCRIPTION
## Description
Tiny fix to stop the menu items moving when navigating pages with and without a scrollbar

### Code

This PR touches:

- [ ] Content
- [x] Frontend
- [ ] Infrastructure
- [ ] Integration Tests
