### PR TITLE
feature: add async Block-powered "Examples" page

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -12,7 +12,8 @@
 				"tutorials/another-tutorial",
 				"tutorials",
 				"reference-guides/sample",
-				"reference-guides"
+				"reference-guides",
+				"examples"
 			],
 			"puppeteerOptions": {
 				"args": [

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,6 +1261,7 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -3196,7 +3197,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -4331,7 +4333,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -4374,7 +4377,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -4603,7 +4607,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -5890,7 +5893,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5914,13 +5918,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5937,19 +5943,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6078,7 +6087,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6092,6 +6102,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6108,6 +6119,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6116,13 +6128,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6143,6 +6157,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6231,7 +6246,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6245,6 +6261,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6347,7 +6364,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6389,6 +6407,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6410,6 +6429,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6458,13 +6478,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6479,6 +6501,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -6494,13 +6517,15 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6510,6 +6535,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6521,6 +6547,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6898,7 +6925,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -7411,7 +7439,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8283,8 +8310,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-svg": {
       "version": "3.0.0",
@@ -8372,6 +8398,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -10561,6 +10596,15 @@
         "semver": "^5.4.1"
       }
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node-fetch-npm": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
@@ -10810,6 +10854,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -13921,8 +13966,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "2.5.2",
@@ -17103,13 +17147,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@dojo/framework": "5.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-solid-svg-icons": "^5.7.1",
+    "isomorphic-fetch": "^2.2.1",
     "tslib": "1.9.3"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,9 @@ import { faAppleAlt } from '@fortawesome/free-solid-svg-icons/faAppleAlt';
 import { faCodeBranch } from '@fortawesome/free-solid-svg-icons/faCodeBranch';
 import { faPlug } from '@fortawesome/free-solid-svg-icons/faPlug';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
+import { faLaptopCode } from '@fortawesome/free-solid-svg-icons/faLaptopCode';
 
-library.add(faCloudDownloadAlt, faGraduationCap, faListAlt, faCodeBranch, faPlug, faUsers, faAppleAlt);
+library.add(faCloudDownloadAlt, faGraduationCap, faListAlt, faCodeBranch, faPlug, faUsers, faAppleAlt, faLaptopCode);
 
 export default class App extends WidgetBase {
 	protected render() {

--- a/src/pages/Examples.m.css
+++ b/src/pages/Examples.m.css
@@ -1,3 +1,55 @@
+@import '../variables.css';
+
 .root {
 	padding: var(--content-top-padding);
+}
+
+.card {
+	display: flex;
+}
+
+.header {
+	background-color: var(--color-off-white);
+	background-position: center;
+	background-size: cover;
+	border-top-left-radius: var(--border-radius);
+	border-top-right-radius: var(--border-radius);
+	flex-grow: 0;
+	flex-shrink: 0;
+	min-height: 204px;
+}
+
+.header:after {
+	background: rgba(0, 0, 0, 0.05);
+	content: '';
+	width: 100%;
+	display: block;
+	height: 100%;
+}
+
+.card:hover .header:after {
+	background: transparent;
+}
+
+.title {
+	margin-bottom: 0.5rem;
+}
+
+.footer {
+	border-top: 1px solid var(--color-border);
+	flex-grow: 0;
+	flex-shrink: 0;
+	text-align: right;
+}
+
+.linkBtn {
+	border-left: 1px solid var(--color-border);
+	color: var(--color-copy);
+	display: inline-block;
+	padding: calc(var(--card-padding) / 2) var(--card-padding);
+}
+
+.linkBtn:hover {
+	box-shadow: 0 0 2px 0 var(--color-border);
+	color: var(--color-dark-copy);
 }

--- a/src/pages/Examples.m.css.d.ts
+++ b/src/pages/Examples.m.css.d.ts
@@ -1,1 +1,6 @@
 export const root: string;
+export const card: string;
+export const header: string;
+export const title: string;
+export const footer: string;
+export const linkBtn: string;

--- a/src/pages/Examples.spec.tsx
+++ b/src/pages/Examples.spec.tsx
@@ -48,7 +48,8 @@ describe('Examples', () => {
 				sandbox: true
 			}
 		]);
-		const h = harness(() => w(mockMetaMixin(Examples, mockMeta), {}));
+		const ExamplesMock = mockMetaMixin(Examples, mockMeta);
+		const h = harness(() => <ExamplesMock />);
 		h.expect(() => (
 			<Landing>
 				<Subsection>

--- a/src/pages/Examples.spec.tsx
+++ b/src/pages/Examples.spec.tsx
@@ -1,16 +1,94 @@
+import Block from '@dojo/framework/widget-core/meta/Block';
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import harness from '@dojo/framework/testing/harness';
+import { Constructor, WidgetMetaConstructor, MetaBase } from '@dojo/framework/widget-core/interfaces';
 import { tsx } from '@dojo/framework/widget-core/tsx';
+import { w } from '@dojo/framework/widget-core/d';
+
+import FontAwesomeIcon from '../widgets/icon/FontAwesomeIcon';
+import Grid from '../widgets/grid/Grid';
+import Landing from '../widgets/Landing';
+import LinkedCard from '../widgets/card/LinkedCard';
+import Subsection from '../widgets/section/Subsection';
 
 import Examples from './Examples';
 import * as css from './Examples.m.css';
 
+const mockMetaMixin = <T extends Constructor<WidgetBase<any>>>(Base: T, mockStub: jest.Mock): T => {
+	return class extends Base {
+		protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
+			return mockStub(MetaType);
+		}
+	};
+};
+
+const mockExamplesBlock = jest.fn();
+
+const mockBlockRun = jest.fn().mockImplementation((input: any) => {
+	return mockExamplesBlock;
+});
+
+const mockMeta = jest.fn().mockImplementation((input: any) => {
+	if (Block) {
+		return {
+			run: mockBlockRun
+		};
+	}
+});
+
 describe('Examples', () => {
 	it('renders', () => {
-		const h = harness(() => <Examples />);
+		mockExamplesBlock.mockReturnValueOnce([
+			{
+				code: 'code',
+				demo: 'demo',
+				example: 'example',
+				exampleName: 'name',
+				overview: 'overview',
+				sandbox: true
+			}
+		]);
+		const h = harness(() => w(mockMetaMixin(Examples, mockMeta), {}));
 		h.expect(() => (
-			<div>
-				<h1 classes={[css.root]}>Examples</h1>
-			</div>
+			<Landing>
+				<Subsection>
+					<h2>Examples</h2>
+					<Grid>
+						<div key="name" classes={css.card}>
+							<LinkedCard
+								footer={
+									<div classes={css.footer}>
+										<a
+											href="https://codesandbox.io/s/github/dojo/examples/tree/master/name"
+											classes={css.linkBtn}
+										>
+											<FontAwesomeIcon icon="laptop-code" />
+										</a>
+										<a
+											href="https://github.com/dojo/examples/tree/master/name"
+											classes={css.linkBtn}
+										>
+											<FontAwesomeIcon icon="code-branch" />
+										</a>
+									</div>
+								}
+								header={
+									<div
+										classes={css.header}
+										styles={{
+											backgroundImage:
+												'url(https://github.com/dojo/examples/raw/master/name/preview.png)'
+										}}
+									/>
+								}
+								url="http://dojo.github.io/examples/name/"
+							>
+								<h4 classes={css.title} />
+							</LinkedCard>
+						</div>
+					</Grid>
+				</Subsection>
+			</Landing>
 		));
 	});
 });

--- a/src/pages/Examples.spec.tsx
+++ b/src/pages/Examples.spec.tsx
@@ -3,7 +3,6 @@ import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import harness from '@dojo/framework/testing/harness';
 import { Constructor, WidgetMetaConstructor, MetaBase } from '@dojo/framework/widget-core/interfaces';
 import { tsx } from '@dojo/framework/widget-core/tsx';
-import { w } from '@dojo/framework/widget-core/d';
 
 import FontAwesomeIcon from '../widgets/icon/FontAwesomeIcon';
 import Grid from '../widgets/grid/Grid';

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -1,14 +1,65 @@
+import Block from '@dojo/framework/widget-core/meta/Block';
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import { tsx } from '@dojo/framework/widget-core/tsx';
+
+import FontAwesomeIcon from '../widgets/icon/FontAwesomeIcon';
+import Grid from '../widgets/grid/Grid';
+import Landing from '../widgets/Landing';
+import LinkedCard from '../widgets/card/LinkedCard';
+import Subsection from '../widgets/section/Subsection';
+import getExamples, { ExampleMeta } from '../scripts/examples.block';
 
 import * as css from './Examples.m.css';
 
 export default class Examples extends WidgetBase {
+	private renderCardHeader = ({ exampleName }: ExampleMeta) => (
+		<div
+			classes={css.header}
+			styles={{
+				backgroundImage: `url(https://github.com/dojo/examples/raw/master/${exampleName}/preview.png)`
+			}}
+		/>
+	);
+
+	private renderCardFooter = ({ exampleName, sandbox }: ExampleMeta) => (
+		<div classes={css.footer}>
+			{sandbox && (
+				<a
+					href={`https://codesandbox.io/s/github/dojo/examples/tree/master/${exampleName}`}
+					classes={css.linkBtn}
+				>
+					<FontAwesomeIcon icon="laptop-code" />
+				</a>
+			)}
+			<a href={`https://github.com/dojo/examples/tree/master/${exampleName}`} classes={css.linkBtn}>
+				<FontAwesomeIcon icon="code-branch" />
+			</a>
+		</div>
+	);
+
 	protected render() {
+		const examples = (this.meta(Block).run(getExamples)() as any) as ExampleMeta[];
+
 		return (
-			<div>
-				<h1 classes={[css.root]}>Examples</h1>
-			</div>
+			<Landing>
+				<Subsection>
+					<h2>Examples</h2>
+					<Grid>
+						{examples.map((example) => (
+							<div key={example.exampleName} classes={css.card}>
+								<LinkedCard
+									footer={this.renderCardFooter(example)}
+									header={this.renderCardHeader(example)}
+									url={`http://dojo.github.io/examples/${example.exampleName}/`}
+								>
+									<h4 classes={css.title}>{example.example.children}</h4>
+									{example.overview.children}
+								</LinkedCard>
+							</div>
+						))}
+					</Grid>
+				</Subsection>
+			</Landing>
 		);
 	}
 }

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -45,18 +45,19 @@ export default class Examples extends WidgetBase {
 				<Subsection>
 					<h2>Examples</h2>
 					<Grid>
-						{examples.map((example) => (
-							<div key={example.exampleName} classes={css.card}>
-								<LinkedCard
-									footer={this.renderCardFooter(example)}
-									header={this.renderCardHeader(example)}
-									url={`http://dojo.github.io/examples/${example.exampleName}/`}
-								>
-									<h4 classes={css.title}>{example.example.children}</h4>
-									{example.overview.children}
-								</LinkedCard>
-							</div>
-						))}
+						{examples &&
+							examples.map((example) => (
+								<div key={example.exampleName} classes={css.card}>
+									<LinkedCard
+										footer={this.renderCardFooter(example)}
+										header={this.renderCardHeader(example)}
+										url={`http://dojo.github.io/examples/${example.exampleName}/`}
+									>
+										<h4 classes={css.title}>{example.example.children}</h4>
+										{example.overview.children}
+									</LinkedCard>
+								</div>
+							))}
 					</Grid>
 				</Subsection>
 			</Landing>

--- a/src/scripts/examples.block.ts
+++ b/src/scripts/examples.block.ts
@@ -1,0 +1,43 @@
+import 'isomorphic-fetch';
+import { VNode } from '@dojo/framework/widget-core/interfaces';
+import { fromMarkdown } from './compile';
+
+const README_URL = 'https://raw.githubusercontent.com/dojo/examples/master/README.md';
+
+export interface ExampleMeta {
+	code: VNode;
+	demo: VNode;
+	example: VNode;
+	exampleName: string;
+	overview: VNode;
+	sandbox?: boolean;
+}
+
+export default async function(): Promise<ExampleMeta[]> {
+	const response = await fetch(README_URL);
+	const text = await response.text();
+	const rows = text.match(/\|.*\|/g)!.map((row) => row.trim());
+	const keys = rows
+		.shift()!
+		.split('|')
+		.map((value) => value.toLowerCase().trim())
+		.filter((value) => value);
+	rows.shift();
+
+	const examples = rows.map((row) => {
+		const data = row
+			.split('|')
+			.map((value) => value.trim())
+			.filter((value) => value);
+		const exampleName = data[1].replace(/((^\[Link\]\(\.\/)|(\)$))/g, '');
+		return {
+			[keys[0]]: fromMarkdown(data[0], {}),
+			[keys[1]]: fromMarkdown(data[1], {}),
+			[keys[2]]: fromMarkdown(data[2], {}),
+			[keys[3]]: data.length === keys.length,
+			[keys[4]]: fromMarkdown(data[4], {}),
+			exampleName
+		};
+	});
+	return (examples as any) as ExampleMeta[];
+}

--- a/src/variables.css
+++ b/src/variables.css
@@ -7,6 +7,9 @@
 	--color-purple: #862790;
 	--color-red: #c42826;
 	--color-green: #2ab770;
+	--color-border: rgba(0, 0, 0, 0.1);
+	--color-copy: #999;
+	--color-dark-copy: #555;
 
 	--border-radius: 4px;
 	--grid-size: 10px;

--- a/src/widgets/Landing.m.css
+++ b/src/widgets/Landing.m.css
@@ -1,0 +1,25 @@
+@import '../variables.css';
+
+.root {
+	padding: var(--content-top-padding) 0;
+	width: 1199px;
+	margin: 0 auto;
+}
+
+@media (max-width: 1240px) {
+	.root {
+		width: 786px;
+	}
+}
+
+@media (max-width: 850px) {
+	.root {
+		width: 373px;
+	}
+}
+
+@media (max-width: 768px) {
+	.root {
+		padding: var(--content-top-padding) var(--content-padding);
+	}
+}

--- a/src/widgets/Landing.m.css.d.ts
+++ b/src/widgets/Landing.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/widgets/Landing.spec.tsx
+++ b/src/widgets/Landing.spec.tsx
@@ -1,0 +1,12 @@
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/widget-core/tsx';
+
+import Landing from './Landing';
+import * as css from './Landing.m.css';
+
+describe('Landing', () => {
+	it('renders', () => {
+		const h = harness(() => <Landing>1337</Landing>);
+		h.expect(() => <div classes={css.root}>1337</div>);
+	});
+});

--- a/src/widgets/Landing.tsx
+++ b/src/widgets/Landing.tsx
@@ -1,0 +1,10 @@
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import { tsx } from '@dojo/framework/widget-core/tsx';
+import { WidgetProperties } from '@dojo/framework/widget-core/interfaces';
+import * as css from './Landing.m.css';
+
+export default class Landing extends WidgetBase<WidgetProperties> {
+	protected render() {
+		return <div classes={css.root}>{this.children}</div>;
+	}
+}

--- a/src/widgets/card/Card.m.css
+++ b/src/widgets/card/Card.m.css
@@ -17,6 +17,8 @@
 	color: #999;
 	padding: calc(var(--grid-size) * 1.5) var(--card-padding) var(--card-padding);
 	box-sizing: border-box;
+	flex-grow: 1;
+	flex-shrink: 1;
 }
 
 .dark {

--- a/src/widgets/section/SectionLanding.m.css.d.ts
+++ b/src/widgets/section/SectionLanding.m.css.d.ts
@@ -1,4 +1,3 @@
-export const root: string;
 export const pageLink: string;
 export const subsection: string;
 export const title: string;

--- a/src/widgets/section/SectionLanding.spec.tsx
+++ b/src/widgets/section/SectionLanding.spec.tsx
@@ -8,6 +8,8 @@ import Block from '@dojo/framework/widget-core/meta/Block';
 import * as sectionListBlock from '../../scripts/section-list.block';
 import Grid from '../grid/Grid';
 import LinkedCard from '../card/LinkedCard';
+import Landing from '../Landing';
+import Subsection from '../section/Subsection';
 
 import SectionLanding from './SectionLanding';
 import * as css from './SectionLanding.m.css';
@@ -75,8 +77,8 @@ describe('Section Landing', () => {
 
 	function expected() {
 		return (
-			<div classes={css.root}>
-				<div key="subsection-Sub-Section 1" classes={css.subsection}>
+			<Landing>
+				<Subsection>
 					<h2>Sub-Section 1</h2>
 					<Grid key="subsection-list-Sub-Section 1">
 						<div key="tutorials-page-tutorials/path/to/one" classes={css.pageLink}>
@@ -100,8 +102,8 @@ describe('Section Landing', () => {
 							</LinkedCard>
 						</div>
 					</Grid>
-				</div>
-				<div key="subsection-Sub-Section 2" classes={css.subsection}>
+				</Subsection>
+				<Subsection>
 					<h2>Sub-Section 2</h2>
 					<Grid key={`subsection-list-Sub-Section 2`}>
 						<div key="tutorials-page-tutorials/path/to/three" classes={css.pageLink}>
@@ -115,8 +117,8 @@ describe('Section Landing', () => {
 							</LinkedCard>
 						</div>
 					</Grid>
-				</div>
-			</div>
+				</Subsection>
+			</Landing>
 		);
 	}
 
@@ -133,7 +135,7 @@ describe('Section Landing', () => {
 
 		const h = harness(() => w(mockMetaMixin(SectionLanding, mockMeta), { section: 'tutorials' }));
 
-		h.expect(() => <div classes={css.root} />);
+		h.expect(() => <Landing />);
 	});
 
 	it('renders empty section landing when section list block returns undefined', () => {
@@ -141,6 +143,6 @@ describe('Section Landing', () => {
 
 		const h = harness(() => w(mockMetaMixin(SectionLanding, mockMeta), { section: 'tutorials' }));
 
-		h.expect(() => <div classes={css.root} />);
+		h.expect(() => <Landing />);
 	});
 });

--- a/src/widgets/section/SectionLanding.tsx
+++ b/src/widgets/section/SectionLanding.tsx
@@ -3,7 +3,9 @@ import Block from '@dojo/framework/widget-core/meta/Block';
 import { tsx } from '@dojo/framework/widget-core/tsx';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 
-import sectionList, { Subsection, PageDefinition } from '../../scripts/section-list.block';
+import Landing from '../Landing';
+import Subsection from './Subsection';
+import sectionList, { Subsection as BlockSubsection, PageDefinition } from '../../scripts/section-list.block';
 import LinkedCard from '../card/LinkedCard';
 import CardIconHeader, { IconHeaderBackgroundColor } from '../card/CardIconHeader';
 import Grid from '../grid/Grid';
@@ -23,14 +25,14 @@ const topicColors: { [key: string]: IconHeaderBackgroundColor } = {
 };
 
 export default class SectionLanding extends WidgetBase<SectionLandingParameters> {
-	private _renderSubsection(subsection: Subsection): DNode {
+	private _renderSubsection(subsection: BlockSubsection): DNode {
 		const { pages, name } = subsection;
 
 		return (
-			<div key={`subsection-${name}`} classes={css.subsection}>
+			<Subsection>
 				<h2>{name}</h2>
 				<Grid key={`subsection-list-${name}`}>{pages.map((page) => this._renderPageCard(page))}</Grid>
-			</div>
+			</Subsection>
 		);
 	}
 
@@ -56,6 +58,6 @@ export default class SectionLanding extends WidgetBase<SectionLandingParameters>
 		const { section } = this.properties;
 		const subsections = this.meta(Block).run(sectionList)(section) || [];
 
-		return <div classes={css.root}>{subsections.map((subsection) => this._renderSubsection(subsection))}</div>;
+		return <Landing>{subsections.map((subsection) => this._renderSubsection(subsection))}</Landing>;
 	}
 }

--- a/src/widgets/section/Subsection.m.css
+++ b/src/widgets/section/Subsection.m.css
@@ -1,15 +1,7 @@
 @import '../../variables.css';
 
-.pageLink {
-	display: flex;
-}
-
-.subsection {
+.root {
 	display: flex;
 	flex-direction: column;
 	margin-bottom: calc(var(--grid-size) * 7);
-}
-
-.title {
-	margin-bottom: 0.5rem;
 }

--- a/src/widgets/section/Subsection.m.css.d.ts
+++ b/src/widgets/section/Subsection.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/widgets/section/Subsection.spec.tsx
+++ b/src/widgets/section/Subsection.spec.tsx
@@ -1,0 +1,12 @@
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/widget-core/tsx';
+
+import Subsection from './Subsection';
+import * as css from './Subsection.m.css';
+
+describe('Subsection', () => {
+	it('renders', () => {
+		const h = harness(() => <Subsection>1337</Subsection>);
+		h.expect(() => <div classes={css.root}>1337</div>);
+	});
+});

--- a/src/widgets/section/Subsection.tsx
+++ b/src/widgets/section/Subsection.tsx
@@ -1,0 +1,11 @@
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import { WidgetProperties } from '@dojo/framework/widget-core/interfaces';
+import { tsx } from '@dojo/framework/widget-core/tsx';
+
+import * as css from './Subsection.m.css';
+
+export default class Subsection extends WidgetBase<WidgetProperties> {
+	protected render() {
+		return <div classes={css.root}>{this.children}</div>;
+	}
+}


### PR DESCRIPTION
## Description

This pull request adds an "Examples" page that's powered by an asynchronous `Block` that pulls data from the [dojo/examples](https://github.com/dojo/examples) README. The design could use some iteration, but the necessary pieces to dynamically build example content are in-place. Existing styles and widgets were leveraged as much as possible.

### Code

This PR touches:

- [x] Content
- [x] Frontend
- [x] Infrastructure
- [x] Integration Tests

### Tests

- [x] Tests are included?

### Screenshots

![preview](https://i.gyazo.com/c2480a77ffe82e3c8e8ffdbd64a71934.gif)
