### PR TITLE
Combine blog meta into a single text node

### DIFF
--- a/src/pages/BlogPost.spec.tsx
+++ b/src/pages/BlogPost.spec.tsx
@@ -50,9 +50,7 @@ describe('Post', () => {
 				<Link to="blog-post" params={{ path: 'path' }} classes={css.headerLink}>
 					<h1 classes={css.header}>title</h1>
 				</Link>
-				<p classes={css.meta}>
-					{'author'} {'October 15, 2018, 12:00 PM'}
-				</p>
+				<p classes={css.meta}>author October 15, 2018, 12:00 PM</p>
 				content
 				<p>
 					<Link to="blog-post" params={{ path: 'path' }} classes={css.readMoreLink}>
@@ -77,9 +75,7 @@ describe('Post', () => {
 		h.expect(() => (
 			<Page classes={{ 'dojo.io/Page': { root: [css.root] } }}>
 				<h1 classes={css.header}>title</h1>
-				<p classes={css.meta}>
-					{'author'} {'October 15, 2018, 12:00 PM'}
-				</p>
+				<p classes={css.meta}>author October 15, 2018, 12:00 PM</p>
 				content
 			</Page>
 		));

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -39,9 +39,7 @@ export default class Post extends WidgetBase<PostProperties> {
 
 		if (post) {
 			const postContent = [
-				<p classes={css.meta}>
-					{post.meta.author} {formatDate(post.meta.date)}
-				</p>,
+				<p classes={css.meta}>{`${post.meta.author} ${formatDate(post.meta.date)}`}</p>,
 				post.content
 			];
 


### PR DESCRIPTION
## Description

Current the blog meta information for author and date creates 3 text nodes, however when hydrating the HTML the vdom system considers it as a single text.  

```html
<p class="BlogPost-m__meta__14EOu">Anthony Gubler January 29, 2019, 8:00 AM</p>
``` 

Meaning that the vdom considers the "space" and the result of `formatDate(post.meta.date)` as extra nodes that need to be rendered and creates duplicate content.

----

<img width="560" alt="dojo_io" src="https://user-images.githubusercontent.com/1982678/58182314-4c1e1a00-7ca5-11e9-813e-3196c4c12b58.png">

----

Currently this is not observed because the merging does not pause for lazyily loaded widgets but it will be come apparent when dojo/site is update to use dojo 6.

This PR changes the 3 text nodes to a single text node.