### PR TITLE
Shore up test coverage and add/switch to new mock meta testing utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9911,6 +9911,12 @@
         "realpath-native": "^1.1.0"
       }
     },
+    "jest-date-mock": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.7.tgz",
+      "integrity": "sha512-ZgbYlURRhVpf52Jho4tlyUgpJJ+nYvhxIWhIIEdarmsSuTxFZlC9DmKCyQXsuEljfxK+7HsqdBX/L6rxwWraYw==",
+      "dev": true
+    },
     "jest-diff": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hast-util-to-string": "1.0.2",
     "husky": "2.2.0",
     "jest": "24.8.0",
+    "jest-date-mock": "^1.0.7",
     "lint-staged": "8.2.0",
     "mdast-util-to-hast": "6.0.1",
     "node-fetch": "2.6.0",
@@ -96,7 +97,10 @@
           ]
         }
       }
-    }
+    },
+    "setupFiles": [
+      "jest-date-mock"
+    ]
   },
   "lint-staged": {
     "*.{ts,tsx,css}": [

--- a/src/pages/Blog.spec.tsx
+++ b/src/pages/Blog.spec.tsx
@@ -14,8 +14,8 @@ import * as css from './Blog.m.css';
 describe('Blog', () => {
 	it('renders', () => {
 		const mockMetaMixin = new MockMetaMixin(Blog);
-
-		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogIndexBlock], () => ['a', 'b', 'c']);
+		const mockCompileBlogIndexBlock = jest.fn().mockReturnValue(['a', 'b', 'c']);
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogIndexBlock], mockCompileBlogIndexBlock);
 
 		const BlogMock = mockMetaMixin.getClass();
 		const h = harness(() => <BlogMock />);
@@ -26,5 +26,7 @@ describe('Blog', () => {
 				<Post path="c" excerpt />
 			</Landing>
 		));
+
+		expect(mockCompileBlogIndexBlock).toHaveBeenCalledWith({ locale: 'en' });
 	});
 });

--- a/src/pages/Blog.spec.tsx
+++ b/src/pages/Blog.spec.tsx
@@ -1,41 +1,23 @@
 import Block from '@dojo/framework/widget-core/meta/Block';
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import harness from '@dojo/framework/testing/harness';
-import { Constructor, WidgetMetaConstructor, MetaBase } from '@dojo/framework/widget-core/interfaces';
 import { tsx } from '@dojo/framework/widget-core/tsx';
 
+import compileBlogIndexBlock from '../scripts/compile-blog-index.block';
 import Landing from '../widgets/landing/Landing';
 import Post from './BlogPost';
+
+import { MockMetaMixin } from '../test/util/MockMeta';
 
 import Blog from './Blog';
 import * as css from './Blog.m.css';
 
-const mockMetaMixin = <T extends Constructor<WidgetBase<any>>>(Base: T, mockStub: jest.Mock): T => {
-	return class extends Base {
-		protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
-			return mockStub(MetaType);
-		}
-	};
-};
-
-const mockCompileBlock = jest.fn();
-
-const mockBlockRun = jest.fn().mockImplementation((input: any) => {
-	return mockCompileBlock;
-});
-
-const mockMeta = jest.fn().mockImplementation((input: any) => {
-	if (Block) {
-		return {
-			run: mockBlockRun
-		};
-	}
-});
-
 describe('Blog', () => {
 	it('renders', () => {
-		mockCompileBlock.mockReturnValueOnce(['a', 'b', 'c']);
-		const BlogMock = mockMetaMixin(Blog, mockMeta);
+		const mockMetaMixin = new MockMetaMixin(Blog);
+
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogIndexBlock], () => ['a', 'b', 'c']);
+
+		const BlogMock = mockMetaMixin.getClass();
 		const h = harness(() => <BlogMock />);
 		h.expect(() => (
 			<Landing classes={{ 'dojo.io/Landing': { root: [css.root] } }}>

--- a/src/pages/BlogPost.spec.tsx
+++ b/src/pages/BlogPost.spec.tsx
@@ -19,14 +19,15 @@ describe('Post', () => {
 	});
 
 	it('renders index page style', () => {
-		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], () => ({
+		const mockCompileBlogPostBlock = jest.fn().mockReturnValue({
 			meta: {
 				author: 'author',
 				date: '2018-10-15 12:00:00',
 				title: 'title'
 			},
 			content: 'content'
-		}));
+		});
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], mockCompileBlogPostBlock);
 
 		const PostMock = mockMetaMixin.getClass();
 
@@ -45,17 +46,23 @@ describe('Post', () => {
 				</p>
 			</LandingSubsection>
 		));
+
+		expect(mockCompileBlogPostBlock).toHaveBeenCalledWith({
+			excerpt: true,
+			path: 'path'
+		});
 	});
 
 	it('renders blog post page style', () => {
-		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], () => ({
+		const mockCompileBlogPostBlock = jest.fn().mockReturnValue({
 			meta: {
 				author: 'author',
 				date: '2018-10-15 12:00:00',
 				title: 'title'
 			},
 			content: 'content'
-		}));
+		});
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], mockCompileBlogPostBlock);
 
 		const PostMock = mockMetaMixin.getClass();
 		const h = harness(() => <PostMock path="path" standalone />);
@@ -66,12 +73,23 @@ describe('Post', () => {
 				content
 			</Page>
 		));
+
+		expect(mockCompileBlogPostBlock).toHaveBeenCalledWith({
+			excerpt: false,
+			path: 'path'
+		});
 	});
 
 	it('does not render if post is not found', () => {
-		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], () => undefined);
+		const mockCompileBlogPostBlock = jest.fn().mockReturnValue(undefined);
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], mockCompileBlogPostBlock);
 		const PostMock = mockMetaMixin.getClass();
 		const h = harness(() => <PostMock path="path" standalone />);
 		h.expect(() => undefined);
+
+		expect(mockCompileBlogPostBlock).toHaveBeenCalledWith({
+			excerpt: false,
+			path: 'path'
+		});
 	});
 });

--- a/src/pages/BlogPost.spec.tsx
+++ b/src/pages/BlogPost.spec.tsx
@@ -1,49 +1,35 @@
 import Block from '@dojo/framework/widget-core/meta/Block';
 import Link from '@dojo/framework/routing/Link';
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import harness from '@dojo/framework/testing/harness';
-import { Constructor, WidgetMetaConstructor, MetaBase } from '@dojo/framework/widget-core/interfaces';
 import { tsx } from '@dojo/framework/widget-core/tsx';
 
+import compileBlogPostBlock from '../scripts/compile-blog-post.block';
 import LandingSubsection from '../widgets/landing/LandingSubsection';
 import Page from '../widgets/page/Page';
+
+import { MockMetaMixin } from '../test/util/MockMeta';
 
 import Post from './BlogPost';
 import * as css from './BlogPost.m.css';
 
-const mockMetaMixin = <T extends Constructor<WidgetBase<any>>>(Base: T, mockStub: jest.Mock): T => {
-	return class extends Base {
-		protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
-			return mockStub(MetaType);
-		}
-	};
-};
-
-const mockCompileBlock = jest.fn();
-
-const mockBlockRun = jest.fn().mockImplementation((input: any) => {
-	return mockCompileBlock;
-});
-
-const mockMeta = jest.fn().mockImplementation((input: any) => {
-	if (Block) {
-		return {
-			run: mockBlockRun
-		};
-	}
-});
-
 describe('Post', () => {
+	let mockMetaMixin: MockMetaMixin<typeof Post>;
+	beforeEach(() => {
+		mockMetaMixin = new MockMetaMixin(Post);
+	});
+
 	it('renders index page style', () => {
-		mockCompileBlock.mockReturnValueOnce({
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], () => ({
 			meta: {
 				author: 'author',
 				date: '2018-10-15 12:00:00',
 				title: 'title'
 			},
 			content: 'content'
-		});
-		const PostMock = mockMetaMixin(Post, mockMeta);
+		}));
+
+		const PostMock = mockMetaMixin.getClass();
+
 		const h = harness(() => <PostMock path="path" excerpt />);
 		h.expect(() => (
 			<LandingSubsection classes={{ 'dojo.io/LandingSubsection': { root: [css.root] } }}>
@@ -62,15 +48,16 @@ describe('Post', () => {
 	});
 
 	it('renders blog post page style', () => {
-		mockCompileBlock.mockReturnValueOnce({
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], () => ({
 			meta: {
 				author: 'author',
 				date: '2018-10-15 12:00:00',
 				title: 'title'
 			},
 			content: 'content'
-		});
-		const PostMock = mockMetaMixin(Post, mockMeta);
+		}));
+
+		const PostMock = mockMetaMixin.getClass();
 		const h = harness(() => <PostMock path="path" standalone />);
 		h.expect(() => (
 			<Page classes={{ 'dojo.io/Page': { root: [css.root] } }}>
@@ -82,8 +69,8 @@ describe('Post', () => {
 	});
 
 	it('does not render if post is not found', () => {
-		mockCompileBlock.mockReturnValueOnce(undefined);
-		const PostMock = mockMetaMixin(Post, mockMeta);
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], () => undefined);
+		const PostMock = mockMetaMixin.getClass();
 		const h = harness(() => <PostMock path="path" standalone />);
 		h.expect(() => undefined);
 	});

--- a/src/pages/Examples.spec.tsx
+++ b/src/pages/Examples.spec.tsx
@@ -1,43 +1,23 @@
 import Block from '@dojo/framework/widget-core/meta/Block';
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import harness from '@dojo/framework/testing/harness';
-import { Constructor, WidgetMetaConstructor, MetaBase } from '@dojo/framework/widget-core/interfaces';
 import { tsx } from '@dojo/framework/widget-core/tsx';
 
+import getExamples from '../scripts/examples.block';
 import FontAwesomeIcon from '../widgets/icon/FontAwesomeIcon';
 import Grid from '../widgets/grid/Grid';
 import Landing from '../widgets/landing/Landing';
 import LandingSubsection from '../widgets/landing/LandingSubsection';
 import LinkedCard from '../widgets/card/LinkedCard';
 
+import { MockMetaMixin } from '../test/util/MockMeta';
+
 import Examples from './Examples';
 import * as css from './Examples.m.css';
 
-const mockMetaMixin = <T extends Constructor<WidgetBase<any>>>(Base: T, mockStub: jest.Mock): T => {
-	return class extends Base {
-		protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
-			return mockStub(MetaType);
-		}
-	};
-};
-
-const mockExamplesBlock = jest.fn();
-
-const mockBlockRun = jest.fn().mockImplementation((input: any) => {
-	return mockExamplesBlock;
-});
-
-const mockMeta = jest.fn().mockImplementation((input: any) => {
-	if (Block) {
-		return {
-			run: mockBlockRun
-		};
-	}
-});
-
 describe('Examples', () => {
 	it('renders', () => {
-		mockExamplesBlock.mockReturnValueOnce([
+		let mockMetaMixin = new MockMetaMixin(Examples);
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [getExamples], () => [
 			{
 				code: 'code',
 				demo: 'demo',
@@ -47,7 +27,7 @@ describe('Examples', () => {
 				sandbox: true
 			}
 		]);
-		const ExamplesMock = mockMetaMixin(Examples, mockMeta);
+		const ExamplesMock = mockMetaMixin.getClass();
 		const h = harness(() => <ExamplesMock />);
 		h.expect(() => (
 			<Landing classes={{ 'dojo.io/Landing': { root: [css.root] } }}>

--- a/src/pages/Examples.spec.tsx
+++ b/src/pages/Examples.spec.tsx
@@ -17,7 +17,7 @@ import * as css from './Examples.m.css';
 describe('Examples', () => {
 	it('renders', () => {
 		let mockMetaMixin = new MockMetaMixin(Examples);
-		mockMetaMixin.registerMetaCallOnce(Block, 'run', [getExamples], () => [
+		const mockGetExample = jest.fn().mockReturnValue([
 			{
 				code: 'code',
 				demo: 'demo',
@@ -27,6 +27,7 @@ describe('Examples', () => {
 				sandbox: true
 			}
 		]);
+		mockMetaMixin.registerMetaCallOnce(Block, 'run', [getExamples], mockGetExample);
 		const ExamplesMock = mockMetaMixin.getClass();
 		const h = harness(() => <ExamplesMock />);
 		h.expect(() => (
@@ -73,5 +74,7 @@ describe('Examples', () => {
 				</LandingSubsection>
 			</Landing>
 		));
+
+		expect(mockGetExample).toHaveBeenCalled();
 	});
 });

--- a/src/pages/home/getgoing/GetGoing.spec.tsx
+++ b/src/pages/home/getgoing/GetGoing.spec.tsx
@@ -109,7 +109,8 @@ describe('GetGoing', () => {
 				isIntersecting: false
 			},
 			{
-				isIntersecting: true
+				value: { isIntersecting: true },
+				shouldInvalidate: true
 			}
 		);
 

--- a/src/pages/home/getgoing/GetGoing.spec.tsx
+++ b/src/pages/home/getgoing/GetGoing.spec.tsx
@@ -1,74 +1,125 @@
 import harness from '@dojo/framework/testing/harness';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import { tsx } from '@dojo/framework/widget-core/tsx';
 import { add } from '@dojo/framework/has/has';
-import * as css from './GetGoing.m.css';
-import Hero from './GetGoing';
+import Intersection from '@dojo/framework/widget-core/meta/Intersection';
+
 import Card from '../../../widgets/card/Card';
 
+import { MockMetaMixin } from '../../../test/util/MockMeta';
+
+import * as css from './GetGoing.m.css';
+import GetGoing from './GetGoing';
+
 describe('GetGoing', () => {
-	it('renders', () => {
-		add('build-time-render', true, false);
-		const h = harness(() => <Hero />);
-		h.expect(() => (
-			<section classes={[css.root]}>
-				<h2>Get Going Quickly</h2>
-				<p classes={[css.headline]}>
-					Getting started with Dojo is simple. You can use your command line of choice and{' '}
-					<a href="https://www.npmjs.com">npm</a> to get going quickly.
-				</p>
-				<div key="cli" classes={[css.cli]}>
-					<Card dark extraClasses={{ root: css.commands, content: css.commandsContent }}>
-						<div classes={[css.command]}>
-							<span classes={[css.commandOne, css.commandOneAnimation]}>
-								npm i @dojo/cli @dojo/cli-create-app -g
-							</span>
-							<span classes={[css.blinkOne]}>|</span>
+	const notPlayingAssertion = assertionTemplate(() => (
+		<section classes={[css.root]}>
+			<h2>Get Going Quickly</h2>
+			<p classes={[css.headline]}>
+				Getting started with Dojo is simple. You can use your command line of choice and{' '}
+				<a href="https://www.npmjs.com">npm</a> to get going quickly.
+			</p>
+			<div key="cli" classes={[css.cli]}>
+				<Card dark classes={{ 'dojo.io/Card': { root: [css.commands], content: [css.commandsContent] } }}>
+					<div classes={[css.command]}>
+						<span assertion-key="commandOne" classes={[css.commandOne, null]}>
+							npm i @dojo/cli @dojo/cli-create-app -g
+						</span>
+						<span assertion-key="blinkOne" classes={[null]}>
+							|
+						</span>
+					</div>
+					<div classes={[css.command]}>
+						<span assertion-key="commandTwo" classes={[css.commandTwo, null]}>
+							dojo create app --name hello-world
+						</span>
+						<span assertion-key="blinkTwo" classes={[null]}>
+							|
+						</span>
+					</div>
+				</Card>
+				<div classes={[css.codeContainer]}>
+					<Card assertion-key="cardOne" dark classes={{ 'dojo.io/Card': { root: [css.hide] } }}>
+						<div classes={[css.codeline]}>
+							<span classes={[css.keyword]}>import</span>
+							<span classes={[css.variable]}>WidgetBase</span>
+							<span classes={[css.keyword]}>from</span>
+							<span classes={[css.string]}>'@dojo/framework/widget-core/WidgetBase'</span>
+							<span>;</span>
 						</div>
-						<div classes={[css.command]}>
-							<span classes={[css.commandTwo, css.commandTwoAnimation]}>
-								dojo create app --name hello-world
-							</span>
-							<span classes={[css.blinkTwo]}>|</span>
+						<div classes={[css.codeline]}>
+							<span classes={[css.keyword]}>import</span>
+							<span classes={[css.variable]}>ProjectorMixin</span>
+							<span classes={[css.keyword]}>from</span>
+							<span classes={[css.string]}>'@dojo/framework/widget-core/Projector'</span>
+							<span>;</span>
+						</div>
+						<div classes={[css.codeline]}>
+							<span classes={[css.keyword]}>import</span>
+							<span>{'{ '}</span>
+							<span classes={[css.variable]}>v</span>
+							<span>{'} '}</span>
+							<span classes={[css.keyword]}>from</span>
+							<span classes={[css.string]}>'@dojo/framework/widget-core/d'</span>
+							<span>;</span>
 						</div>
 					</Card>
-					<div classes={[css.codeContainer]}>
-						<Card dark extraClasses={{ root: css.code }}>
-							<div classes={[css.codeline]}>
-								<span classes={[css.keyword]}>import</span>
-								<span classes={[css.variable]}>WidgetBase</span>
-								<span classes={[css.keyword]}>from</span>
-								<span classes={[css.string]}>'@dojo/framework/widget-core/WidgetBase'</span>
-								<span>;</span>
-							</div>
-							<div classes={[css.codeline]}>
-								<span classes={[css.keyword]}>import</span>
-								<span classes={[css.variable]}>ProjectorMixin</span>
-								<span classes={[css.keyword]}>from</span>
-								<span classes={[css.string]}>'@dojo/framework/widget-core/Projector'</span>
-								<span>;</span>
-							</div>
-							<div classes={[css.codeline]}>
-								<span classes={[css.keyword]}>import</span>
-								<span>{'{ '}</span>
-								<span classes={[css.variable]}>v</span>
-								<span>{'} '}</span>
-								<span classes={[css.keyword]}>from</span>
-								<span classes={[css.string]}>'@dojo/framework/widget-core/d'</span>
-								<span>;</span>
-							</div>
-						</Card>
-						<Card
-							extraClasses={{
-								root: css.result,
-								content: css.resultContent
-							}}
-						>
-							<div classes={[css.check]}>✔</div>
-							<div>Success!</div>
-						</Card>
-					</div>
+					<Card
+						assertion-key="cardTwo"
+						classes={{ 'dojo.io/Card': { root: [css.hide], content: [css.resultContent] } }}
+					>
+						<div classes={[css.check]}>✔</div>
+						<div>Success!</div>
+					</Card>
 				</div>
-			</section>
-		));
+			</div>
+		</section>
+	));
+
+	const playingAssertion = notPlayingAssertion
+		.setProperty('~commandOne', 'classes', [css.commandOne, css.commandOneAnimation])
+		.setProperty('~commandTwo', 'classes', [css.commandTwo, css.commandTwoAnimation])
+		.setProperty('~blinkOne', 'classes', [css.blinkOne])
+		.setProperty('~blinkTwo', 'classes', [css.blinkTwo])
+		.setProperty('~cardOne', 'classes', { 'dojo.io/Card': { root: [css.code] } })
+		.setProperty('~cardTwo', 'classes', { 'dojo.io/Card': { root: [css.result], content: [css.resultContent] } });
+
+	it('renders not playing', () => {
+		add('build-time-render', false, true);
+		const h = harness(() => <GetGoing />);
+		h.expect(notPlayingAssertion);
+	});
+
+	it('renders playing', () => {
+		add('build-time-render', true, true);
+		const h = harness(() => <GetGoing />);
+		h.expect(playingAssertion);
+	});
+
+	it('starts playing on intersection', () => {
+		jest.useFakeTimers();
+		add('build-time-render', false, true);
+
+		const mockMetaMixin = new MockMetaMixin(GetGoing);
+		mockMetaMixin.registerMetaCallOnce(
+			Intersection,
+			'get',
+			['cli'],
+			{
+				isIntersecting: false
+			},
+			{
+				isIntersecting: true
+			}
+		);
+
+		const MockGetGoing = mockMetaMixin.getClass();
+
+		const h = harness(() => <MockGetGoing />);
+		h.expect(notPlayingAssertion);
+
+		jest.runAllTimers();
+
+		h.expect(playingAssertion);
 	});
 });

--- a/src/pages/home/getgoing/GetGoing.tsx
+++ b/src/pages/home/getgoing/GetGoing.tsx
@@ -19,7 +19,7 @@ export default class GetGoing extends WidgetBase {
 					<a href="https://www.npmjs.com">npm</a> to get going quickly.
 				</p>
 				<div key="cli" classes={[css.cli]}>
-					<Card dark extraClasses={{ root: css.commands, content: css.commandsContent }}>
+					<Card dark classes={{ 'dojo.io/Card': { root: [css.commands], content: [css.commandsContent] } }}>
 						<div classes={[css.command]}>
 							<span classes={[css.commandOne, play ? css.commandOneAnimation : null]}>
 								npm i @dojo/cli @dojo/cli-create-app -g
@@ -34,7 +34,7 @@ export default class GetGoing extends WidgetBase {
 						</div>
 					</Card>
 					<div classes={[css.codeContainer]}>
-						<Card dark extraClasses={{ root: play ? css.code : css.hide }}>
+						<Card dark classes={{ 'dojo.io/Card': { root: [play ? css.code : css.hide] } }}>
 							<div classes={[css.codeline]}>
 								<span classes={[css.keyword]}>import</span>
 								<span classes={[css.variable]}>WidgetBase</span>
@@ -60,9 +60,8 @@ export default class GetGoing extends WidgetBase {
 							</div>
 						</Card>
 						<Card
-							extraClasses={{
-								root: play ? css.result : css.hide,
-								content: css.resultContent
+							classes={{
+								'dojo.io/Card': { root: [play ? css.result : css.hide], content: [css.resultContent] }
 							}}
 						>
 							<div classes={[css.check]}>✔</div>

--- a/src/scripts/blog-rss.spec.ts
+++ b/src/scripts/blog-rss.spec.ts
@@ -1,0 +1,152 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { Feed } from 'feed';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { BlogFile } from './compile-blog-index.block';
+import { createBlogFeed } from './blog-rss';
+
+jest.mock('fs');
+jest.mock('fs-extra');
+
+describe('Blog RSS', () => {
+	let outputFileSyncMock: jest.SpyInstance;
+
+	const blog1: BlogFile = {
+		sortDate: new Date(2019, 6, 1),
+		meta: {
+			title: 'Announcing Version 6 of Dojo',
+			date: new Date(2019, 6, 1),
+			author: 'Anthony Gubler'
+		},
+		file: 'blog/en/version-6-dojo.md',
+		content: `
+---
+title: Announcing Dojo 6.0.0
+date: 2019-06-01T00:00:00.000Z
+author: Anthony Gubler
+---
+
+## Dojo version 6 has arrived!
+
+We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda.
+
+![Announcing Dojo 5.0.0](/assets/blog/version-5-dojo/featured.png)
+<!-- more -->
+
+### New Features
+
+Yadda yadda yadda yadda yadda yadda yadda yadda.
+      `
+	};
+
+	const blog2: BlogFile = {
+		sortDate: new Date('2018-10-15 12:00:00'),
+		meta: {
+			title: 'Announcing Version 4 of Dojo',
+			date: new Date('2018-10-15 12:00:00'),
+			author: 'Paul Shannon'
+		},
+		file: 'blog/en/version-4-dojo.md',
+		content: `
+---
+title: Announcing Version 4 of Dojo
+date: 2018-10-15T12:00:00.000Z
+author: Paul Shannon
+---
+## Being a Better Dojo
+
+Developer ergonomics, efficient source code, consistent and flexible architecture, interoperability and alignment with modern standards, and strong community support are fundamental reasons for choosing a framework. We’re constantly looking for ways to improve Dojo and provide the community with the best possible modern framework.
+
+![Announcing Version 4 of Dojo](/assets/blog/version-4-dojo/featured.png)
+<!-- more -->
+
+## Dojo CLI Tooling
+
+The main focus of version 4 of Dojo is improving application optimization and analyzing, focusing on tooling that can enable these features by default. Separating a Dojo application into bundles (often referred to as code splitting) has been possible since the initial Dojo release. Although this did not require you to change your source code, it did require adding some configuration to specify how your application should be bundled. We wanted to do better by default and in version 4, the [Dojo build tooling will automatically split an application based on its top-level routes](https://github.com/dojo/cli-build-app#code-splitting-by-route)!
+
+The application template used by \`cli-build-app\` provides this functionality out of the box. In addition to this a bundle analyzer is automatically generated when running a build in production mode, providing even more insight into you bundles.
+      `
+	};
+
+	const blog3: BlogFile = {
+		sortDate: new Date(),
+		meta: {},
+		file: 'blog/en/no-meta-blog.md',
+		content: `## A blog without any meta`
+	};
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+
+		outputFileSyncMock = jest.spyOn(fs, 'outputFileSync').mockImplementation(() => {});
+		jest.spyOn(path, 'join').mockImplementation(() => 'path/to/some/atom.xml');
+
+		advanceTo(new Date(2019, 5, 13, 0, 0, 0)); // reset to date time.
+	});
+
+	afterEach(() => {
+		clear();
+	});
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('should render blog rss feed', () => {
+		createBlogFeed([blog1, blog2, blog3]);
+
+		const feed = new Feed({
+			title: 'Dojo',
+			description: 'The official blog of the Dojo framework',
+			id: 'https://dojo.io/blog',
+			link: 'https://dojo.io/blog',
+			favicon: 'https://dojo.io/favicon.ico',
+			copyright: 'All rights reserved 2019, SitePen',
+			feedLinks: {
+				atom: 'https://dojo.io/atom'
+			},
+			author: {
+				name: 'SitePen'
+			},
+			feed: ''
+		});
+
+		const item = {
+			title: 'Announcing Version 6 of Dojo',
+			id: 'https://dojo.io/blog/version-6-dojo',
+			author: [{ name: 'Anthony Gubler' }],
+			link: 'https://dojo.io/blog/version-6-dojo',
+			description: `<h2>Dojo version 6 has arrived!</h2>
+<p>We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda.</p>
+<p><img src="/assets/blog/version-5-dojo/featured.png" alt="Announcing Dojo 5.0.0"></p>`,
+			content: `<h2>Dojo version 6 has arrived!</h2>
+<p>We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda.</p>
+<p><img src="/assets/blog/version-5-dojo/featured.png" alt="Announcing Dojo 5.0.0"></p>
+<h3>New Features</h3>
+<p>Yadda yadda yadda yadda yadda yadda yadda yadda.
+</p>`,
+			date: new Date(2019, 6, 1),
+			published: new Date(2019, 6, 1)
+		};
+
+		// feed
+		feed.addItem(item);
+
+		const item3 = {
+			title: '',
+			id: 'https://dojo.io/blog/no-meta-blog',
+			author: [{ name: '' }],
+			link: 'https://dojo.io/blog/no-meta-blog',
+			description: `<h2>A blog without any meta</h2>`,
+			content: `<h2>A blog without any meta</h2>`,
+			date: new Date(),
+			published: new Date()
+		};
+
+		// feed
+		feed.addItem(item3);
+
+		expect(outputFileSyncMock).toBeCalledWith('path/to/some/atom.xml', feed.atom1());
+	});
+});

--- a/src/scripts/blog-rss.ts
+++ b/src/scripts/blog-rss.ts
@@ -25,7 +25,7 @@ export interface BlogEntry {
 // In order to not spam people's RSS feed when this goes live, we skip items before May 2019
 const skipItemsBefore = new Date(2019, 4, 1).getTime();
 
-export function createBlogFeed(files: BlogFile[], contentRoot: string) {
+export function createBlogFeed(files: BlogFile[]) {
 	const feed = new Feed({
 		title: 'Dojo',
 		description: 'The official blog of the Dojo framework',
@@ -42,12 +42,12 @@ export function createBlogFeed(files: BlogFile[], contentRoot: string) {
 		feed: ''
 	});
 
-	for (const file of files) {
+	for (let file of files) {
 		const { title, date, author } = file.meta;
 		const publishedDate = date instanceof Date ? date : new Date();
 
 		if (publishedDate.getTime() < skipItemsBefore) {
-			break;
+			continue;
 		}
 
 		const fullContentProcessed = fromMarkdown(file.content, registerHandlers(handlers));

--- a/src/scripts/compile-blog-index.block.ts
+++ b/src/scripts/compile-blog-index.block.ts
@@ -41,7 +41,7 @@ export default async function(options: CompileBlogIndex) {
 
 	blogs.sort((a, b) => b.sortDate.getTime() - a.sortDate.getTime());
 
-	createBlogFeed(blogs, contentPath);
+	createBlogFeed(blogs);
 
 	return blogs.map((blog) => blog.file);
 }

--- a/src/scripts/util.ts
+++ b/src/scripts/util.ts
@@ -17,7 +17,7 @@ export interface TextNode {
 	value: string;
 }
 
-export type YamlData = { [key: string]: YamlData } | string | boolean;
+export type YamlData = { [key: string]: YamlData } | string | boolean | Date;
 
 export interface YamlNode {
 	type: 'yaml';

--- a/src/test/util/MockMeta.spec.tsx
+++ b/src/test/util/MockMeta.spec.tsx
@@ -229,7 +229,7 @@ describe('MockMeta', () => {
 		}
 	}
 
-	test('automatic invalidation', () => {
+	test('invalidation', () => {
 		// Must use fake timers for proper testing
 		jest.useFakeTimers();
 
@@ -242,7 +242,10 @@ describe('MockMeta', () => {
 				isIntersecting: false
 			},
 			{
-				isIntersecting: true
+				value: {
+					isIntersecting: true
+				},
+				shouldInvalidate: true
 			}
 		);
 

--- a/src/test/util/MockMeta.spec.tsx
+++ b/src/test/util/MockMeta.spec.tsx
@@ -1,0 +1,176 @@
+import harness from '@dojo/framework/testing/harness';
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import { tsx } from '@dojo/framework/widget-core/tsx';
+import Focus from '@dojo/framework/widget-core/meta/Focus';
+import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
+import Intersection from '@dojo/framework/widget-core/meta/Intersection';
+
+import { MockMetaMixin } from './MockMeta';
+
+describe('MockMeta', () => {
+	class MetaWidgetOnce extends WidgetBase {
+		protected render() {
+			expect(this.meta(Focus).set('root')).toBeUndefined();
+
+			// Root Focus.get() call one
+			expect(this.meta(Focus).get('root')).toEqual({
+				active: false,
+				containsFocus: true
+			});
+
+			// Order does not matter between different arguements
+			expect(this.meta(Focus).get('notRoot')).toEqual({
+				active: true,
+				containsFocus: true
+			});
+
+			// Root Focus.get() call two
+			expect(this.meta(Focus).get('root')).toEqual({
+				active: false,
+				containsFocus: false
+			});
+
+			// Order does not matter between different metas
+			expect(this.meta(Dimensions).get('root')).toEqual({
+				size: {
+					width: 24,
+					height: 24
+				}
+			});
+
+			// Root Focus.get() call three
+			expect(this.meta(Focus).get('root')).toEqual({
+				active: false,
+				containsFocus: true
+			});
+
+			// No 4th registered call for root
+			expect(() => this.meta(Focus).get('root')).toThrowError(
+				'Arguements ["root"] were registered 3 time(s) for Focus.get() but have been called 4 time(s)'
+			);
+
+			// Not registered so an error is thrown
+			expect(() => this.meta(Focus).get('notRegistered')).toThrowError(
+				'Arguements ["notRegistered"] not registered for Focus.get()'
+			);
+
+			// Not registered so an error is thrown
+			expect(() => this.meta(Intersection).get('root')).toThrowError("Meta 'Intersection' not registered");
+
+			return <div key="root" />;
+		}
+	}
+
+	test('registerMetaCallOnce', () => {
+		const mockMetaMixin = new MockMetaMixin(MetaWidgetOnce);
+
+		// Register two calls at once
+		mockMetaMixin.registerMetaCallOnce(
+			Focus,
+			'get',
+			['root'],
+			{
+				active: false,
+				containsFocus: true
+			},
+			{
+				active: false,
+				containsFocus: false
+			}
+		);
+
+		// Register one additional call (the 3rd call)
+		mockMetaMixin.registerMetaCallOnce(Focus, 'get', ['root'], {
+			active: false,
+			containsFocus: true
+		});
+
+		// Register a different meta for the same arguements
+		mockMetaMixin.registerMetaCall(Dimensions, 'get', ['root'], {
+			size: {
+				width: 24,
+				height: 24
+			}
+		});
+
+		// Register 'get' method but with different arguements and to always return the same value no matter the number of calls
+		mockMetaMixin.registerMetaCall(Focus, 'get', ['notRoot'], {
+			active: true,
+			containsFocus: true
+		});
+
+		// Register a call to 'set' for root. Order in registering only matters within same function/arguements
+		mockMetaMixin.registerMetaCallOnce(Focus, 'set', ['root'], undefined);
+
+		const TestFocusWidget = mockMetaMixin.getClass();
+
+		const h = harness(() => <TestFocusWidget />);
+		h.expect(() => <div key="root" />);
+	});
+
+	class MetaWidget extends WidgetBase {
+		protected render() {
+			// Registered to always return the same value no matter the number of calls
+			expect(this.meta(Focus).get('root')).toEqual({
+				active: true,
+				containsFocus: false
+			});
+
+			// Order does not matter between different metas
+			expect(this.meta(Dimensions).get('root')).toEqual({
+				size: {
+					width: 24,
+					height: 24
+				}
+			});
+
+			// Root Focus.get() call two
+			expect(this.meta(Focus).get('root')).toEqual({
+				active: true,
+				containsFocus: false
+			});
+
+			// Root Dimensions.get() call two
+			expect(this.meta(Dimensions).get('root')).toEqual({
+				size: {
+					width: 24,
+					height: 24
+				}
+			});
+
+			// Not registered so an error is thrown
+			expect(() => this.meta(Focus).set('root')).toThrowError("Method 'set' not registered for meta Focus");
+
+			return <div key="root" />;
+		}
+	}
+
+	test('registerMetaCall', () => {
+		const mockMetaMixin = new MockMetaMixin(MetaWidget);
+
+		// Register 'get' method to always return the same value no matter the number of calls
+		mockMetaMixin.registerMetaCall(Focus, 'get', ['root'], {
+			active: true,
+			containsFocus: true
+		});
+
+		// Overrides previous 'registerMetaCall' call
+		mockMetaMixin.registerMetaCall(Focus, 'get', ['root'], {
+			active: true,
+			containsFocus: false
+		});
+
+		// Register a different meta for the same arguements
+		mockMetaMixin.registerMetaCall(Dimensions, 'get', ['root'], {
+			size: {
+				width: 24,
+				height: 24
+			}
+		});
+
+		const TestFocusWidget = mockMetaMixin.getClass();
+
+		const h = harness(() => <TestFocusWidget />);
+		h.expect(() => <div key="root" />);
+	});
+});

--- a/src/test/util/MockMeta.ts
+++ b/src/test/util/MockMeta.ts
@@ -65,9 +65,7 @@ export class MockMetaMixin<T extends Constructor<WidgetBase<any>>> {
 
 						if (values.length === 0) {
 							throw new Error(
-								`Arguements ${JSON.stringify(args)} were registered ${total} time(s) for ${
-									MetaType.name
-								}.${method}() but have been called ${count} time(s)`
+								`Arguements ${argValues} were registered ${total} time(s) for ${MetaType.name}.${method}() but have been called ${count} time(s)`
 							);
 						}
 						return values.shift();

--- a/src/test/util/MockMeta.ts
+++ b/src/test/util/MockMeta.ts
@@ -1,0 +1,167 @@
+import { Constructor, MetaBase, WidgetMetaConstructor } from '@dojo/framework/widget-core/interfaces';
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import Map from '@dojo/framework/shim/Map';
+
+type MetaFunction = <M extends MetaBase>(MetaType: WidgetMetaConstructor<M>) => any;
+
+export class MockMetaMixin<T extends Constructor<WidgetBase<any>>> {
+	private mockMetaMixin = (Base: T, mockStub: MetaFunction): T => {
+		return class extends Base {
+			private handle: any;
+
+			protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
+				return mockStub(MetaType);
+			}
+
+			/**
+			 * Overriding render helps with testing metas that invalidate their host when their values change.
+			 */
+			protected render() {
+				this.handle && clearTimeout(this.handle);
+				this.handle = setTimeout(() => this.invalidate());
+				return super.render();
+			}
+		};
+	};
+
+	private mockMeta = <M extends MetaBase, F extends jest.FunctionPropertyNames<M>>(
+		MetaType: WidgetMetaConstructor<M>
+	): any => {
+		if (!this.values[MetaType.name]) {
+			throw new Error(`Meta '${MetaType.name}' not registered`);
+		}
+
+		const base = Object.getOwnPropertyNames(MetaType.prototype)
+			.filter((key) => key !== 'constructor' && !key.startsWith('_'))
+			.reduce(
+				(current, method: string) => {
+					current[method] = (...args: any) => {
+						throw new Error(`Method '${method}' not registered for meta ${MetaType.name}`);
+					};
+
+					return current;
+				},
+				{} as {
+					[key: string]: (...args: any) => any;
+				}
+			);
+
+		return {
+			...base,
+			...Object.keys(this.values[MetaType.name]).reduce(
+				(current, method: string) => {
+					current[method] = (...args: jest.ArgsType<Required<M>[F]>) => {
+						const argValues = this.getArgString(args);
+						const argReturnValues = this.values[MetaType.name][method].get(argValues);
+						if (!argReturnValues) {
+							throw new Error(`Arguements ${argValues} not registered for ${MetaType.name}.${method}()`);
+						}
+						argReturnValues.count++;
+						const { count, total, values, value } = argReturnValues;
+
+						if (value) {
+							return value;
+						}
+
+						if (values.length === 0) {
+							throw new Error(
+								`Arguements ${JSON.stringify(args)} were registered ${total} time(s) for ${
+									MetaType.name
+								}.${method}() but have been called ${count} time(s)`
+							);
+						}
+						return values.shift();
+					};
+					return current;
+				},
+				{} as {
+					[key: string]: (...args: jest.ArgsType<Required<M>[F]>) => any;
+				}
+			)
+		};
+	};
+
+	private values: {
+		[key: string]: {
+			[method: string]: Map<
+				string | Function,
+				{
+					count: number;
+					total: number;
+					values: any[];
+					value: any;
+				}
+			>;
+		};
+	} = {};
+
+	private Node: T;
+
+	constructor(Node: T) {
+		this.Node = Node;
+	}
+
+	public registerMetaCall<M extends MetaBase, F extends jest.FunctionPropertyNames<M>>(
+		MetaType: WidgetMetaConstructor<M>,
+		method: F,
+		args: jest.ArgsType<Required<M>[F]>,
+		value: Required<M>[F] extends (...args: any[]) => any
+			? (ReturnType<Required<M>[F]> | Partial<ReturnType<Required<M>[F]>>)
+			: never
+	) {
+		if (!this.values[MetaType.name]) {
+			this.values[MetaType.name] = {};
+		}
+		if (!this.values[MetaType.name][method]) {
+			this.values[MetaType.name][method] = new Map();
+		}
+		const argValues = this.getArgString(args);
+		this.values[MetaType.name][method].set(argValues, {
+			count: 0,
+			total: 1,
+			values: [],
+			value
+		});
+	}
+
+	public registerMetaCallOnce<M extends MetaBase, F extends jest.FunctionPropertyNames<M>>(
+		MetaType: WidgetMetaConstructor<M>,
+		method: F,
+		args: jest.ArgsType<Required<M>[F]>,
+		...values: (Required<M>[F] extends (...args: any[]) => any
+			? (ReturnType<Required<M>[F]> | Partial<ReturnType<Required<M>[F]>>)
+			: never)[]
+	) {
+		if (!this.values[MetaType.name]) {
+			this.values[MetaType.name] = {};
+		}
+		if (!this.values[MetaType.name][method]) {
+			this.values[MetaType.name][method] = new Map();
+		}
+		const argValues = this.getArgString(args);
+		let argReturnValues = this.values[MetaType.name][method].get(argValues);
+		if (!argReturnValues) {
+			argReturnValues = {
+				count: 0,
+				total: 0,
+				values: [],
+				value: undefined
+			};
+			this.values[MetaType.name][method].set(argValues, argReturnValues);
+		}
+
+		argReturnValues.total += values.length;
+		argReturnValues.values.push(...values);
+	}
+
+	private getArgString(args: any[]): string | Function {
+		if (args.length === 1 && typeof args[0] === 'function') {
+			return args[0];
+		}
+		return JSON.stringify(args);
+	}
+
+	public getClass() {
+		return this.mockMetaMixin(this.Node, this.mockMeta);
+	}
+}

--- a/src/widgets/code/CodeSandbox.spec.tsx
+++ b/src/widgets/code/CodeSandbox.spec.tsx
@@ -38,7 +38,8 @@ describe('CodeSandbox', () => {
 				isIntersecting: false
 			},
 			{
-				isIntersecting: true
+				value: { isIntersecting: true },
+				shouldInvalidate: true
 			}
 		);
 		const CodeSandboxMock = mockMetaMixin.getClass();

--- a/src/widgets/code/CodeSandbox.spec.tsx
+++ b/src/widgets/code/CodeSandbox.spec.tsx
@@ -1,13 +1,13 @@
 import harness from '@dojo/framework/testing/harness';
 import { tsx } from '@dojo/framework/widget-core/tsx';
-import { w } from '@dojo/framework/widget-core/d';
 import { add } from '@dojo/framework/has/has';
-import { Constructor, MetaBase, WidgetMetaConstructor } from '@dojo/framework/widget-core/interfaces';
-import { Intersection } from '@dojo/framework/widget-core/meta/Intersection';
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import Intersection from '@dojo/framework/widget-core/meta/Intersection';
+
+import { MockMetaMixin } from '../../test/util/MockMeta';
 
 import CodeSandbox from './CodeSandbox';
 import * as css from './CodeSandbox.m.css';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 
 const noop: any = () => {};
 
@@ -17,45 +17,38 @@ export const stubEvent = {
 	target: {}
 };
 
-const mockMetaMixin = <T extends Constructor<WidgetBase<any>>>(Base: T, mockStub: jest.Mock): T => {
-	return class extends Base {
-		protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
-			return mockStub(MetaType);
-		}
-	};
-};
-
 describe('CodeSandbox', () => {
+	const baseAssertion = assertionTemplate(() => (
+		<div key="root" classes={[css.root]}>
+			<iframe assertion-key="iframe" classes={[css.root]} src="" />
+		</div>
+	));
+
 	it('renders', () => {
+		jest.useFakeTimers();
 		add('build-time-render', false, true);
 		const url = 'https://codesandbox.io/embed/dummy';
 
-		const mockMeta = jest.fn().mockImplementation((input: any) => {
-			if (Intersection) {
-				return {
-					get: mockIntersectionGet
-				};
+		let mockMetaMixin = new MockMetaMixin(CodeSandbox);
+		mockMetaMixin.registerMetaCallOnce(
+			Intersection,
+			'get',
+			['root'],
+			{
+				isIntersecting: false
+			},
+			{
+				isIntersecting: true
 			}
-		});
+		);
+		const CodeSandboxMock = mockMetaMixin.getClass();
 
-		const mockIntersectionGet = jest
-			.fn()
-			.mockReturnValueOnce({ isIntersecting: false })
-			.mockReturnValueOnce({ isIntersecting: true });
+		const h = harness(() => <CodeSandboxMock url={url} />);
+		h.expect(baseAssertion);
 
-		const h = harness(() => w(mockMetaMixin(CodeSandbox, mockMeta), { url }));
-		h.expect(() => (
-			<div key="root" classes={[css.root]}>
-				<iframe classes={[css.root]} src="" />
-			</div>
-		));
+		jest.runAllTimers();
 
-		const h2 = harness(() => w(mockMetaMixin(CodeSandbox, mockMeta), { url }));
-		h2.expect(() => (
-			<div key="root" classes={[css.root]}>
-				<iframe classes={[css.root]} src={`${url}?autoresize=1&hidenavigation=1`} />
-			</div>
-		));
+		h.expect(baseAssertion.setProperty('~iframe', 'src', `${url}?autoresize=1&hidenavigation=1`));
 	});
 
 	it('does not render during build-time-rendering', () => {


### PR DESCRIPTION
## Description

<!-- Describe at a high level what the PR achieves -->
- Improve test coverage in areas lacking.
- Add `MockMeta` utility to help with testing widgets that make use of one or more of Dojo's metas (Focus, Block, Dimensions, Intersection, etc).
  - **The code being tested**:
    ```tsx
    const { active, containsFocus } = this.meta(Focus).get('popupMenu');
    if (active || containsFocus) {
    	if (!this.hasHadFocus) {
    		onFocus && onFocus();
    	}
    	this.hasHadFocus = true;
    }
  1. Create `MockMeta` instance, passing in the widget to attach the mocked Metas too.
      ```tsx
      const mockMetaMixin = new MockMetaMixin(PopupMenu);
      ```
  2. Register calls to specific metas (using some inspiration from Jest for type safety).
      1. Register once (similar to `mockReturnValueOnce`). Can take multiple return values (as additional arguments) to register multiple calls at once.
          ```tsx
          /**
           * Arguments:
           * - Meta to register
           * - Function within meta to mock
           * - Arguments to pass to mocked function
           * - The value to return when the mock function is called with the provided arguements
           */
          mockMetaMixin.registerMetaCallOnce(Focus, 'get', ['popupMenu'], {
          	active: false,
          	containsFocus: true
          });
          ```
      2. Register for all calls (similar to `mockReturnValue`).
          ```tsx
          mockMetaMixin.registerMetaCall(Focus, 'get', ['popupMenu'], {
          	active: false,
          	containsFocus: true
          });
          ```
  3. Get mocked up class for use in harness.
      ```tsx
      const MockPopupMenu = mockMetaMixin.getClass();
      ```
  4. Run tests with mocked up class.
      ```tsx
      const h = harness(() => <MockPopupMenu items={[]} onFocus={onFocus} />);
      h.expect(baseAssertionTemplate);
      
      expect(onFocus).toHaveBeenCalled();
      ```

### Code

This PR touches:

- [ ] Content
- [x] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [x] Tests are included?