### PR TITLE
Fix blog index rendering order issue

### DIFF
--- a/content/blog/en/announcing-dojo-2-beta-4.md
+++ b/content/blog/en/announcing-dojo-2-beta-4.md
@@ -1,6 +1,6 @@
 ---
 title: Announcing Dojo 2 beta 4!
-date: 2017-12-04 18:00:00
+date: 2017-12-04T18:00:00.000Z
 author: Kitson Kelly
 ---
 

--- a/content/blog/en/announcing-dojo-2-beta-5.md
+++ b/content/blog/en/announcing-dojo-2-beta-5.md
@@ -1,6 +1,6 @@
 ---
 title: Announcing Dojo 2 beta 5!
-date: 2018-01-23 09:00:00
+date: 2018-01-23T09:00:00.000Z
 author: Dylan Schiemann
 ---
 

--- a/content/blog/en/building-pwa-dojo.md
+++ b/content/blog/en/building-pwa-dojo.md
@@ -1,6 +1,6 @@
 ---
 title: Building Progressive Web Apps With Dojo
-date: 2018-09-13T08:00:00Z
+date: 2018-09-13T08:00:00.000Z
 author: Matt Wistrand
 ---
 ![Building Progressive Web Apps with Dojo](/assets/blog/building-pwa-dojo/featured.jpg)

--- a/content/blog/en/dojo-2-is-coming.md
+++ b/content/blog/en/dojo-2-is-coming.md
@@ -1,6 +1,6 @@
 ---
 title: Dojo 2 is coming
-date: 2017-03-27 14:32:37
+date: 2017-03-27T14:32:37.000Z
 author: Dylan Schiemann
 ---
 

--- a/content/blog/en/dojo-2-rc1.md
+++ b/content/blog/en/dojo-2-rc1.md
@@ -1,6 +1,6 @@
 ---
 title: Dojo 2 Release Candidate 1 is now available!
-date: 2018-03-11 09:00:00
+date: 2018-03-11T09:00:00.000Z
 author: Dylan Schiemann
 ---
 

--- a/content/blog/en/dojo-version-3-release.md
+++ b/content/blog/en/dojo-version-3-release.md
@@ -1,6 +1,6 @@
 ---
 title: Dojo Version 3.0
-date: 2018-07-27 08:00:00
+date: 2018-07-27T08:00:00.000Z
 author: Paul Shannon
 ---
 ![Dojo Version 3.0](/assets/blog/dojo2-0-0-release/featured.jpg)

--- a/content/blog/en/dojo2-0-0-release.md
+++ b/content/blog/en/dojo2-0-0-release.md
@@ -1,6 +1,6 @@
 ---
 title: Introducing Dojo 2.0!
-date: 2018-05-02T17:00:00Z
+date: 2018-05-02T17:00:00.000Z
 author: Dylan Schiemann
 ---
 

--- a/src/pages/Blog.spec.tsx
+++ b/src/pages/Blog.spec.tsx
@@ -10,20 +10,24 @@ import { MockMetaMixin } from '../test/util/MockMeta';
 
 import Blog from './Blog';
 import * as css from './Blog.m.css';
+import { blogPost1Excerpt, blogPost2Excerpt, blogPost3, blogPost4 } from '../test/blog-posts.mock';
 
 describe('Blog', () => {
 	it('renders', () => {
 		const mockMetaMixin = new MockMetaMixin(Blog);
-		const mockCompileBlogIndexBlock = jest.fn().mockReturnValue(['a', 'b', 'c']);
+		const mockCompileBlogIndexBlock = jest
+			.fn()
+			.mockReturnValue([blogPost1Excerpt, blogPost2Excerpt, blogPost3, blogPost4]);
 		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogIndexBlock], mockCompileBlogIndexBlock);
 
 		const BlogMock = mockMetaMixin.getClass();
 		const h = harness(() => <BlogMock />);
 		h.expect(() => (
 			<Landing classes={{ 'dojo.io/Landing': { root: [css.root] } }}>
-				<Post path="a" excerpt />
-				<Post path="b" excerpt />
-				<Post path="c" excerpt />
+				<Post key={blogPost1Excerpt.file} post={blogPost1Excerpt} excerpt />
+				<Post key={blogPost2Excerpt.file} post={blogPost2Excerpt} excerpt />
+				<Post key={blogPost3.file} post={blogPost3} excerpt />
+				<Post key={blogPost4.file} post={blogPost4} excerpt />
 			</Landing>
 		));
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -3,6 +3,7 @@ import WidgetBase from '@dojo/framework/core/WidgetBase';
 import { tsx } from '@dojo/framework/core/vdom';
 
 import compileBlogIndexBlock from '../scripts/compile-blog-index.block';
+import { BlogPost } from '../scripts/compile-blog-post.block';
 import Landing from '../widgets/landing/Landing';
 
 import Post from './BlogPost';
@@ -10,11 +11,11 @@ import * as css from './Blog.m.css';
 
 export default class Blog extends WidgetBase {
 	protected render() {
-		const paths: any = this.meta(Block).run(compileBlogIndexBlock)({ locale: 'en' });
+		const blogs: BlogPost[] = this.meta(Block).run(compileBlogIndexBlock)({ locale: 'en' }) as any;
 
 		return (
 			<Landing classes={{ 'dojo.io/Landing': { root: [css.root] } }}>
-				{paths && paths.map((path: string) => <Post path={path} excerpt />)}
+				{blogs && blogs.map((blog: BlogPost) => <Post key={blog.file} post={blog} excerpt />)}
 			</Landing>
 		);
 	}

--- a/src/pages/BlogPost.spec.tsx
+++ b/src/pages/BlogPost.spec.tsx
@@ -8,8 +8,9 @@ import LandingSubsection from '../widgets/landing/LandingSubsection';
 import Page from '../widgets/page/Page';
 
 import { MockMetaMixin } from '../test/util/MockMeta';
+import { blogPost2Full, blogPost2Excerpt } from '../test/blog-posts.mock';
 
-import Post from './BlogPost';
+import Post, { formatDate } from './BlogPost';
 import * as css from './BlogPost.m.css';
 
 describe('Post', () => {
@@ -18,29 +19,42 @@ describe('Post', () => {
 		mockMetaMixin = new MockMetaMixin(Post);
 	});
 
-	it('renders index page style', () => {
-		const mockCompileBlogPostBlock = jest.fn().mockReturnValue({
-			meta: {
-				author: 'author',
-				date: '2018-10-15 12:00:00',
-				title: 'title'
-			},
-			content: 'content'
-		});
+	it('renders from provided post', () => {
+		const PostMock = mockMetaMixin.getClass();
+
+		const h = harness(() => <PostMock post={blogPost2Excerpt} excerpt />);
+		h.expect(() => (
+			<LandingSubsection classes={{ 'dojo.io/LandingSubsection': { root: [css.root] } }}>
+				<Link to="blog-post" params={{ path: 'version-6-dojo' }} classes={css.headerLink}>
+					<h1 classes={css.header}>Announcing Version 6 of Dojo</h1>
+				</Link>
+				<p classes={css.meta}>{`Anthony Gubler ${formatDate(blogPost2Excerpt.meta.date as string)}`}</p>
+				{blogPost2Excerpt.content}
+				<p>
+					<Link to="blog-post" params={{ path: 'version-6-dojo' }} classes={css.readMoreLink}>
+						READ MORE
+					</Link>
+				</p>
+			</LandingSubsection>
+		));
+	});
+
+	it('renders excerpt style', () => {
+		const mockCompileBlogPostBlock = jest.fn().mockReturnValue(blogPost2Excerpt);
 		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], mockCompileBlogPostBlock);
 
 		const PostMock = mockMetaMixin.getClass();
 
-		const h = harness(() => <PostMock path="path" excerpt />);
+		const h = harness(() => <PostMock path="version-6-dojo" excerpt />);
 		h.expect(() => (
 			<LandingSubsection classes={{ 'dojo.io/LandingSubsection': { root: [css.root] } }}>
-				<Link to="blog-post" params={{ path: 'path' }} classes={css.headerLink}>
-					<h1 classes={css.header}>title</h1>
+				<Link to="blog-post" params={{ path: 'version-6-dojo' }} classes={css.headerLink}>
+					<h1 classes={css.header}>Announcing Version 6 of Dojo</h1>
 				</Link>
-				<p classes={css.meta}>author October 15, 2018, 12:00 PM</p>
-				content
+				<p classes={css.meta}>{`Anthony Gubler ${formatDate(blogPost2Excerpt.meta.date as string)}`}</p>
+				{blogPost2Excerpt.content}
 				<p>
-					<Link to="blog-post" params={{ path: 'path' }} classes={css.readMoreLink}>
+					<Link to="blog-post" params={{ path: 'version-6-dojo' }} classes={css.readMoreLink}>
 						READ MORE
 					</Link>
 				</p>
@@ -49,34 +63,27 @@ describe('Post', () => {
 
 		expect(mockCompileBlogPostBlock).toHaveBeenCalledWith({
 			excerpt: true,
-			path: 'path'
+			path: 'version-6-dojo'
 		});
 	});
 
 	it('renders blog post page style', () => {
-		const mockCompileBlogPostBlock = jest.fn().mockReturnValue({
-			meta: {
-				author: 'author',
-				date: '2018-10-15 12:00:00',
-				title: 'title'
-			},
-			content: 'content'
-		});
+		const mockCompileBlogPostBlock = jest.fn().mockReturnValue(blogPost2Full);
 		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], mockCompileBlogPostBlock);
 
 		const PostMock = mockMetaMixin.getClass();
-		const h = harness(() => <PostMock path="path" standalone />);
+		const h = harness(() => <PostMock path="version-6-dojo" standalone />);
 		h.expect(() => (
 			<Page classes={{ 'dojo.io/Page': { root: [css.root] } }}>
-				<h1 classes={css.header}>title</h1>
-				<p classes={css.meta}>author October 15, 2018, 12:00 PM</p>
-				content
+				<h1 classes={css.header}>Announcing Version 6 of Dojo</h1>
+				<p classes={css.meta}>{`Anthony Gubler ${formatDate(blogPost2Full.meta.date as string)}`}</p>
+				{blogPost2Full.content}
 			</Page>
 		));
 
 		expect(mockCompileBlogPostBlock).toHaveBeenCalledWith({
 			excerpt: false,
-			path: 'path'
+			path: 'version-6-dojo'
 		});
 	});
 
@@ -84,12 +91,12 @@ describe('Post', () => {
 		const mockCompileBlogPostBlock = jest.fn().mockReturnValue(undefined);
 		mockMetaMixin.registerMetaCallOnce(Block, 'run', [compileBlogPostBlock], mockCompileBlogPostBlock);
 		const PostMock = mockMetaMixin.getClass();
-		const h = harness(() => <PostMock path="path" standalone />);
+		const h = harness(() => <PostMock path="version-6-dojo" standalone />);
 		h.expect(() => undefined);
 
 		expect(mockCompileBlogPostBlock).toHaveBeenCalledWith({
 			excerpt: false,
-			path: 'path'
+			path: 'version-6-dojo'
 		});
 	});
 });

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -3,7 +3,7 @@ import Block from '@dojo/framework/core/meta/Block';
 import { tsx } from '@dojo/framework/core/vdom';
 import Link from '@dojo/framework/routing/Link';
 
-import compileBlogPostBlock from '../scripts/compile-blog-post.block';
+import compileBlogPostBlock, { BlogPost } from '../scripts/compile-blog-post.block';
 
 import LandingSubsection from '../widgets/landing/LandingSubsection';
 import Page from '../widgets/page/Page';
@@ -13,7 +13,8 @@ import * as css from './BlogPost.m.css';
 export interface PostProperties {
 	excerpt?: boolean;
 	standalone?: boolean;
-	path: string;
+	path?: string;
+	post?: BlogPost;
 }
 
 export function formatDate(date: string) {
@@ -22,7 +23,7 @@ export function formatDate(date: string) {
 		year: 'numeric',
 		month: 'long',
 		day: '2-digit',
-		hour: '2-digit',
+		hour: 'numeric',
 		minute: '2-digit'
 	};
 
@@ -31,15 +32,19 @@ export function formatDate(date: string) {
 
 export default class Post extends WidgetBase<PostProperties> {
 	protected render() {
+		let { post } = this.properties;
 		const { excerpt = false, standalone = false, path } = this.properties;
-		const post: any = this.meta(Block).run(compileBlogPostBlock)({
-			excerpt,
-			path
-		});
+
+		if (!post && path) {
+			post = this.meta(Block).run(compileBlogPostBlock)({
+				excerpt,
+				path
+			}) as any;
+		}
 
 		if (post) {
 			const postContent = [
-				<p classes={css.meta}>{`${post.meta.author} ${formatDate(post.meta.date)}`}</p>,
+				<p classes={css.meta}>{`${post.meta.author} ${formatDate(post.meta.date as string)}`}</p>,
 				post.content
 			];
 
@@ -48,7 +53,7 @@ export default class Post extends WidgetBase<PostProperties> {
 					<Link
 						to="blog-post"
 						params={{
-							path: path.replace('blog/en/', '').replace('.md', '')
+							path: post.file.replace('blog/en/', '').replace('.md', '')
 						}}
 						classes={css.readMoreLink}
 					>
@@ -72,7 +77,7 @@ export default class Post extends WidgetBase<PostProperties> {
 					<Link
 						to="blog-post"
 						params={{
-							path: path.replace('blog/en/', '').replace('.md', '')
+							path: post.file.replace('blog/en/', '').replace('.md', '')
 						}}
 						classes={css.headerLink}
 					>

--- a/src/scripts/blog-rss.spec.ts
+++ b/src/scripts/blog-rss.spec.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import { Feed } from 'feed';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { BlogFile } from './compile-blog-index.block';
 import { createBlogFeed } from './blog-rss';
+import { BlogPost } from './compile-blog-post.block';
 
 jest.mock('fs');
 jest.mock('fs-extra');
@@ -12,7 +12,7 @@ jest.mock('fs-extra');
 describe('Blog RSS', () => {
 	let outputFileSyncMock: jest.SpyInstance;
 
-	const blog1: BlogFile = {
+	const blog1: BlogPost = {
 		sortDate: new Date(2019, 6, 1),
 		meta: {
 			title: 'Announcing Version 6 of Dojo',
@@ -20,7 +20,8 @@ describe('Blog RSS', () => {
 			author: 'Anthony Gubler'
 		},
 		file: 'blog/en/version-6-dojo.md',
-		content: `
+		content: false,
+		rawContent: `
 ---
 title: Announcing Dojo 6.0.0
 date: 2019-06-01T00:00:00.000Z
@@ -40,7 +41,7 @@ Yadda yadda yadda yadda yadda yadda yadda yadda.
       `
 	};
 
-	const blog2: BlogFile = {
+	const blog2: BlogPost = {
 		sortDate: new Date('2018-10-15 12:00:00'),
 		meta: {
 			title: 'Announcing Version 4 of Dojo',
@@ -48,7 +49,8 @@ Yadda yadda yadda yadda yadda yadda yadda yadda.
 			author: 'Paul Shannon'
 		},
 		file: 'blog/en/version-4-dojo.md',
-		content: `
+		content: false,
+		rawContent: `
 ---
 title: Announcing Version 4 of Dojo
 date: 2018-10-15T12:00:00.000Z
@@ -69,11 +71,12 @@ The application template used by \`cli-build-app\` provides this functionality o
       `
 	};
 
-	const blog3: BlogFile = {
+	const blog3: BlogPost = {
 		sortDate: new Date(),
 		meta: {},
 		file: 'blog/en/no-meta-blog.md',
-		content: `## A blog without any meta`
+		content: false,
+		rawContent: '## A blog without any meta'
 	};
 
 	beforeEach(() => {

--- a/src/scripts/blog-rss.ts
+++ b/src/scripts/blog-rss.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { outputFileSync } from 'fs-extra';
 
 import { registerHandlers, handlers, fromMarkdown } from './compile';
-import { BlogFile } from './compile-blog-index.block';
+import { BlogPost } from './compile-blog-post.block';
 
 const unified = require('unified');
 const stringify = require('rehype-stringify');
@@ -25,7 +25,7 @@ export interface BlogEntry {
 // In order to not spam people's RSS feed when this goes live, we skip items before May 2019
 const skipItemsBefore = new Date(2019, 4, 1).getTime();
 
-export function createBlogFeed(files: BlogFile[]) {
+export function createBlogFeed(files: BlogPost[]) {
 	const feed = new Feed({
 		title: 'Dojo',
 		description: 'The official blog of the Dojo framework',
@@ -50,12 +50,15 @@ export function createBlogFeed(files: BlogFile[]) {
 			continue;
 		}
 
-		const fullContentProcessed = fromMarkdown(file.content, registerHandlers(handlers));
+		const fullContentProcessed = fromMarkdown(file.rawContent, registerHandlers(handlers));
 		const fullContent = unified()
 			.use(stringify)
 			.stringify(fullContentProcessed);
 
-		const descriptionProcessed = fromMarkdown(file.content.split('<!-- more -->')[0], registerHandlers(handlers));
+		const descriptionProcessed = fromMarkdown(
+			file.rawContent.split('<!-- more -->')[0],
+			registerHandlers(handlers)
+		);
 		const description = unified()
 			.use(stringify)
 			.stringify(descriptionProcessed);

--- a/src/scripts/compile-blog-index.block.ts
+++ b/src/scripts/compile-blog-index.block.ts
@@ -1,9 +1,9 @@
 import { join } from 'canonical-path';
 import { readdir } from 'fs-extra';
 
-import { getLocalFile, getMetaData } from './compile';
-import { YamlData } from './util';
+import { getLocalFile, getMetaData, toDNodes, fromMarkdown, registerHandlers, handlers } from './compile';
 import { createBlogFeed } from './blog-rss';
+import { BlogPost } from './compile-blog-post.block';
 
 const CONTENT_PATH = join(__dirname, '../../content/blog');
 
@@ -11,31 +11,26 @@ interface CompileBlogIndex {
 	locale?: string;
 }
 
-export interface BlogFile {
-	sortDate: Date;
-	meta: {
-		[key: string]: YamlData;
-	};
-	file: string;
-	content: string;
-}
-
 export default async function(options: CompileBlogIndex) {
 	const { locale = 'en' } = options;
 	const contentPath = join(CONTENT_PATH, locale);
 
 	const files = await readdir(contentPath);
-	const blogs: BlogFile[] = [];
+	const blogs: BlogPost[] = [];
 
 	for (let file of files) {
-		const content = await getLocalFile(join(contentPath, file));
-		const blogMetaData = getMetaData(content);
+		let rawContent = await getLocalFile(join(contentPath, file));
+		rawContent = rawContent.split('<!-- more -->')[0];
+
+		const content = toDNodes(fromMarkdown(rawContent, registerHandlers(handlers)));
+		const blogMetaData = getMetaData(rawContent);
 
 		blogs.push({
-			sortDate: new Date(`${blogMetaData.date}`),
+			sortDate: blogMetaData.date ? new Date(`${blogMetaData.date}`) : new Date(),
 			meta: blogMetaData,
 			file: join('blog', locale, file),
-			content
+			content,
+			rawContent
 		});
 	}
 
@@ -43,5 +38,5 @@ export default async function(options: CompileBlogIndex) {
 
 	createBlogFeed(blogs);
 
-	return blogs.map((blog) => blog.file);
+	return blogs;
 }

--- a/src/scripts/compile-blog-post.block.spec.ts
+++ b/src/scripts/compile-blog-post.block.spec.ts
@@ -1,63 +1,9 @@
-import { v, w } from '@dojo/framework/core/vdom';
-
 import * as path from 'canonical-path';
+
+import { file2, blogPost2Full, blogPost2Excerpt } from '../test/blog-posts.mock';
 
 import * as compiler from './compile';
 import compileBlogPostBlock from './compile-blog-post.block';
-
-const blog = `
----
-title: Blog Title
-date: 2018-10-15 12:00:00
-author: Paul Shannon
----
-## Blog Title
-
-A excerpt for this blog post!
-
-[BlogImage path="path/to/an/image.png"]
-
-<!-- more -->
-
-## After the break!
-
-More information
-`;
-
-const excerpt = [
-	v('h2', { key: 'compiledKey' }, ['Blog Title']),
-	`
-`,
-	v('p', { key: 'compiledKey' }, ['A excerpt for this blog post!']),
-	`
-`,
-	w('docs-blogimage', { key: 'compiledKey', path: 'path/to/an/image.png' } as any, [])
-];
-
-const restOfPost = [
-	`
-`,
-	v('h2', { key: 'compiledKey' }, ['After the break!']),
-	`
-`,
-	v('p', { key: 'compiledKey' }, ['More information'])
-];
-
-const meta = {
-	title: 'Blog Title',
-	date: new Date('2018-10-15T12:00:00.000Z'),
-	author: 'Paul Shannon'
-};
-
-const expectedFullOutput = {
-	content: v('div', { key: 'compiledKey' }, [...excerpt, ...restOfPost]),
-	meta
-};
-
-const expectedExcerptOutput = {
-	content: v('div', { key: 'compiledKey' }, [...excerpt]),
-	meta
-};
 
 describe('compile blog post block', () => {
 	const mockJoin = jest.spyOn(path, 'join');
@@ -68,19 +14,19 @@ describe('compile blog post block', () => {
 		jest.resetAllMocks();
 
 		mockJoin.mockReturnValue('content/blog/en/post.md');
-		mockGetLocalFile.mockReturnValue(Promise.resolve(blog));
+		mockGetLocalFile.mockReturnValue(Promise.resolve(file2));
 		mockGetCompiledKey.mockReturnValue('compiledKey');
 	});
 
 	it('parses and returns full file', async () => {
-		const result = await compileBlogPostBlock({ path: 'blog/en/post.md' });
+		const result = await compileBlogPostBlock({ path: 'blog/en/version-6-dojo.md' });
 
-		expect(result).toEqual(expectedFullOutput);
+		expect(result).toEqual(blogPost2Full);
 	});
 
 	it('parses and returns excerpt', async () => {
-		const result = await compileBlogPostBlock({ path: 'blog/en/post.md', excerpt: true });
+		const result = await compileBlogPostBlock({ path: 'blog/en/version-6-dojo.md', excerpt: true });
 
-		expect(result).toEqual(expectedExcerptOutput);
+		expect(result).toEqual(blogPost2Excerpt);
 	});
 });

--- a/src/scripts/compile-blog-post.block.ts
+++ b/src/scripts/compile-blog-post.block.ts
@@ -1,12 +1,24 @@
 import { join } from 'canonical-path';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 import { registerHandlers, handlers, fromMarkdown, getLocalFile, getMetaData, toDNodes } from './compile';
+import { YamlData } from './util';
 
 const CONTENT_PATH = join(__dirname, '../../content');
 
 interface CompileBlogPost {
 	excerpt?: boolean;
 	path: string;
+}
+
+export interface BlogPost {
+	content: DNode;
+	rawContent: string;
+	meta: {
+		[key: string]: YamlData;
+	};
+	file: string;
+	sortDate: Date;
 }
 
 export default async function(options: CompileBlogPost): Promise<any> {
@@ -19,5 +31,8 @@ export default async function(options: CompileBlogPost): Promise<any> {
 
 	const content = toDNodes(fromMarkdown(rawContent, registerHandlers(handlers)));
 	const meta = await getMetaData(rawContent);
-	return { content, meta };
+
+	const post: BlogPost = { content, meta, file: path, sortDate: new Date(`${meta.date}`), rawContent };
+
+	return post;
 }

--- a/src/test/blog-posts.mock.tsx
+++ b/src/test/blog-posts.mock.tsx
@@ -1,0 +1,204 @@
+import { BlogPost } from '../scripts/compile-blog-post.block';
+import { tsx, v } from '@dojo/framework/core/vdom';
+import { advanceTo, clear } from 'jest-date-mock';
+
+advanceTo(new Date(2019, 5, 13, 0, 0, 0)); // reset to date time.
+
+export const fileList = ['version-4-dojo.md', 'version-6-dojo.md', 'file3.md', 'no-meta-blog.md'];
+export const filePathList = [
+	'blog/en/version-4-dojo.md',
+	'blog/en/version-6-dojo.md',
+	'blog/en/file3.md',
+	'blog/en/no-meta-blog.md'
+];
+
+export const file1 = `
+---
+title: Announcing Version 4 of Dojo
+date: 2018-10-15T12:00:00.000Z
+author: Paul Shannon
+---
+## Being a Better Dojo
+
+Developer ergonomics, efficient source code, consistent and flexible architecture, interoperability and alignment with modern standards, and strong community support are fundamental reasons for choosing a framework. We’re constantly looking for ways to improve Dojo and provide the community with the best possible modern framework.
+
+![Announcing Version 4 of Dojo](/assets/blog/version-4-dojo/featured.png)
+<!-- more -->
+
+## Dojo CLI Tooling
+
+The main focus of version 4 of Dojo is improving application optimization and analyzing, focusing on tooling that can enable these features by default. Separating a Dojo application into bundles (often referred to as code splitting) has been possible since the initial Dojo release. Although this did not require you to change your source code, it did require adding some configuration to specify how your application should be bundled. We wanted to do better by default and in version 4, the [Dojo build tooling will automatically split an application based on its top-level routes](https://github.com/dojo/cli-build-app#code-splitting-by-route)!
+
+The application template used by \`cli-build-app\` provides this functionality out of the box. In addition to this a bundle analyzer is automatically generated when running a build in production mode, providing even more insight into you bundles.
+`;
+
+export const blogPost1Excerpt: BlogPost = {
+	file: 'blog/en/version-4-dojo.md',
+	rawContent: `
+---
+title: Announcing Version 4 of Dojo
+date: 2018-10-15T12:00:00.000Z
+author: Paul Shannon
+---
+## Being a Better Dojo
+
+Developer ergonomics, efficient source code, consistent and flexible architecture, interoperability and alignment with modern standards, and strong community support are fundamental reasons for choosing a framework. We’re constantly looking for ways to improve Dojo and provide the community with the best possible modern framework.
+
+![Announcing Version 4 of Dojo](/assets/blog/version-4-dojo/featured.png)
+`,
+	sortDate: new Date('2018-10-15T12:00:00.000Z'),
+	meta: {
+		title: 'Announcing Version 4 of Dojo',
+		date: new Date('2018-10-15T12:00:00.000Z'),
+		author: 'Paul Shannon'
+	},
+	content: v('div', { key: 'compiledKey' }, [
+		v('h2', { key: 'compiledKey' }, ['Being a Better Dojo']),
+		`
+`,
+		v('p', { key: 'compiledKey' }, [
+			'Developer ergonomics, efficient source code, consistent and flexible architecture, interoperability and alignment with modern standards, and strong community support are fundamental reasons for choosing a framework. We’re constantly looking for ways to improve Dojo and provide the community with the best possible modern framework.'
+		]),
+		`
+`,
+		v('p', { key: 'compiledKey' }, [
+			v(
+				'img',
+				{
+					key: 'compiledKey',
+					src: '/assets/blog/version-4-dojo/featured.png',
+					alt: 'Announcing Version 4 of Dojo'
+				},
+				undefined
+			)
+		])
+	])
+};
+
+export const file2 = `
+---
+title: Announcing Version 6 of Dojo
+date: 2019-06-01T00:00:00.000Z
+author: Anthony Gubler
+---
+
+## Dojo version 6 has arrived!
+
+We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda.
+
+![Announcing Dojo 5.0.0](/assets/blog/version-5-dojo/featured.png)
+<!-- more -->
+
+### New Features
+
+Yadda yadda yadda yadda yadda yadda yadda yadda.
+`;
+
+export const blogPost2Excerpt: BlogPost = {
+	file: 'blog/en/version-6-dojo.md',
+	rawContent: `
+---
+title: Announcing Version 6 of Dojo
+date: 2019-06-01T00:00:00.000Z
+author: Anthony Gubler
+---
+
+## Dojo version 6 has arrived!
+
+We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda.
+
+![Announcing Dojo 5.0.0](/assets/blog/version-5-dojo/featured.png)
+`,
+	sortDate: new Date('2019-06-01T00:00:00.000Z'),
+	meta: {
+		title: 'Announcing Version 6 of Dojo',
+		date: new Date('2019-06-01T00:00:00.000Z'),
+		author: 'Anthony Gubler'
+	},
+	content: v('div', { key: 'compiledKey' }, [
+		v('h2', { key: 'compiledKey' }, ['Dojo version 6 has arrived!']),
+		`
+`,
+		v('p', { key: 'compiledKey' }, [
+			"We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda."
+		]),
+		`
+`,
+		v('p', { key: 'compiledKey' }, [
+			v(
+				'img',
+				{ key: 'compiledKey', src: '/assets/blog/version-5-dojo/featured.png', alt: 'Announcing Dojo 5.0.0' },
+				undefined
+			)
+		])
+	])
+};
+
+export const blogPost2Full: BlogPost = {
+	file: 'blog/en/version-6-dojo.md',
+	rawContent: file2,
+	sortDate: new Date('2019-06-01T00:00:00.000Z'),
+	meta: {
+		title: 'Announcing Version 6 of Dojo',
+		date: new Date('2019-06-01T00:00:00.000Z'),
+		author: 'Anthony Gubler'
+	},
+	content: v('div', { key: 'compiledKey' }, [
+		v('h2', { key: 'compiledKey' }, ['Dojo version 6 has arrived!']),
+		`
+`,
+		v('p', { key: 'compiledKey' }, [
+			"We're excited to announce the 6.0.0 release of Dojo. Yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda yadda."
+		]),
+		`
+`,
+		v('p', { key: 'compiledKey' }, [
+			v(
+				'img',
+				{ key: 'compiledKey', src: '/assets/blog/version-5-dojo/featured.png', alt: 'Announcing Dojo 5.0.0' },
+				undefined
+			)
+		]),
+		`
+`,
+		v('h3', { key: 'compiledKey' }, ['New Features']),
+		`
+`,
+		v('p', { key: 'compiledKey' }, ['Yadda yadda yadda yadda yadda yadda yadda yadda.'])
+	])
+};
+
+export const file3 = `
+---
+title: Blog Title 3
+date: 2017-01-05 08:00:00Z
+author: Paul Shannon
+---
+## Blog Title 3
+`;
+
+export const blogPost3: BlogPost = {
+	file: 'blog/en/file3.md',
+	rawContent: file3,
+	sortDate: new Date('2017-01-05 08:00:00Z'),
+	meta: {
+		title: 'Blog Title 3',
+		date: new Date('2017-01-05 08:00:00Z'),
+		author: 'Paul Shannon'
+	},
+	content: <h2 key="compiledKey">Blog Title 3</h2>
+};
+
+export const file4 = `\
+## A blog without any meta
+`;
+
+export const blogPost4: BlogPost = {
+	file: 'blog/en/no-meta-blog.md',
+	rawContent: file4,
+	sortDate: new Date(),
+	meta: {},
+	content: <h2 key="compiledKey">A blog without any meta</h2>
+};
+
+clear();


### PR DESCRIPTION
## Description

<!-- Describe at a high level what the PR achieves -->
- Fix blog rendering order issue by only relying on a single `Block` (`compile-blog-index.block`), instead of getting the list from `compile-blog-index.block` then calling `compile-blog-post.block` for each blog).
- Add centralized test data for blogs.

### Code

This PR touches:

- [ ] Content
- [x] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [x] Tests are included?