### PR TITLE
Add version selector

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,25 @@
+import { Version } from './interface';
+
+/* Outlets */
+export const outlets = {
+	home: 'home',
+	blog: {
+		home: 'blog',
+		post: 'blog-post'
+	},
+	examples: 'examples',
+	playground: 'playground',
+	roadmap: 'roadmap',
+	community: 'community',
+	referenceGuides: 'reference-guides'
+};
+
+/* Versions */
+export const currentVersion: Version = {
+	name: '6.0.0',
+	shortName: 'v6',
+	current: true,
+	tag: 'stable'
+};
+
+export const versions: Version[] = [currentVersion];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,0 +1,6 @@
+export interface Version {
+	name: string;
+	shortName: string;
+	current?: boolean;
+	tag?: 'stable' | 'next';
+}

--- a/src/test/util/MockWindow.spec.ts
+++ b/src/test/util/MockWindow.spec.ts
@@ -1,0 +1,45 @@
+import { mockWindow } from './MockWindow';
+
+describe('MockWindow', () => {
+	const saveLocation = window.location;
+
+	afterAll(() => {
+		delete window.location;
+		window.location = saveLocation;
+	});
+
+	it('assigns the location when passed to mock directly', () => {
+		const { assign } = mockWindow('http://foo.com').location;
+
+		expect(window.location.href).toBe('http://foo.com/');
+
+		assign.mockClear();
+	});
+
+	it('location.assign assigns a location', () => {
+		const { assign } = mockWindow().location;
+		assign('http://foo.com');
+
+		expect(window.location.href).toBe('http://foo.com/');
+
+		assign.mockClear();
+	});
+
+	it('location.replace replaces a location', () => {
+		const { replace } = mockWindow().location;
+		replace('http://bar.com');
+
+		expect(window.location.href).toBe('http://bar.com/');
+
+		replace.mockClear();
+	});
+
+	it('location.reload is a spy', () => {
+		const { reload } = mockWindow().location;
+		reload();
+
+		expect(window.location.reload).toHaveBeenCalledTimes(1);
+
+		reload.mockClear();
+	});
+});

--- a/src/test/util/MockWindow.ts
+++ b/src/test/util/MockWindow.ts
@@ -1,0 +1,26 @@
+interface MockedLocation extends Location {
+	assign: jest.Mock<void, [string]>;
+	reload: jest.Mock;
+	replace: jest.Mock<void, [string]>;
+}
+
+interface MockedWindow extends Window {
+	location: MockedLocation;
+}
+
+export function mockWindow(href = window.location.href) {
+	const win: Window = window;
+	const locationMocks: Partial<MockedLocation> = {
+		assign: jest.fn().mockImplementation(replaceLocation),
+		reload: jest.fn(),
+		replace: jest.fn().mockImplementation(replaceLocation)
+	};
+
+	return replaceLocation(href);
+
+	function replaceLocation(url: string) {
+		delete win.location;
+		win.location = Object.assign(new URL(url), locationMocks) as any;
+		return win as MockedWindow;
+	}
+}

--- a/src/variables.css
+++ b/src/variables.css
@@ -1,6 +1,7 @@
 :root {
 	/* Color Pallette */
 	--color-white: #ffffff;
+	--color-surface: #f5f6f8;
 	--color-off-white: #aaa;
 	--color-black: #000000;
 	--color-light-blue: #009dff;
@@ -72,6 +73,12 @@
 	--content-top-padding: calc(var(--grid-size) * 6);
 	--content-padding: calc(var(--grid-size) * 3);
 	--console-background-color: var(--darker-background-color);
+
+	/* Z indexes */
+	--zindex-dropdown: 500;
+
+	/* Elevation */
+	--box-shadow-high-evelation: 0px 10px 16px rgba(0, 0, 0, 0.2);
 }
 
 @media (max-width: 768px) {

--- a/src/widgets/accessibility-link-button/AccessibilityLinkButton.m.css
+++ b/src/widgets/accessibility-link-button/AccessibilityLinkButton.m.css
@@ -1,0 +1,9 @@
+@import '../../variables.css';
+
+.root {
+	display: flex;
+	text-decoration: none;
+	padding: 0;
+	color: unset;
+	cursor: pointer;
+}

--- a/src/widgets/accessibility-link-button/AccessibilityLinkButton.m.css.d.ts
+++ b/src/widgets/accessibility-link-button/AccessibilityLinkButton.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/widgets/accessibility-link-button/AccessibilityLinkButton.spec.tsx
+++ b/src/widgets/accessibility-link-button/AccessibilityLinkButton.spec.tsx
@@ -1,0 +1,125 @@
+import harness from '@dojo/framework/testing/harness';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import { tsx } from '@dojo/framework/core/vdom';
+import Link from '@dojo/framework/routing/Link';
+
+import AccessibilityLinkButton from './AccessibilityLinkButton';
+import * as css from './AccessibilityLinkButton.m.css';
+
+describe('AccessibilityLinkButton', () => {
+	describe('Link', () => {
+		const linkAssertion = assertionTemplate(() => (
+			<Link key={undefined} disabled={false} classes={css.root} to="outlet">
+				Some content
+			</Link>
+		));
+
+		it('should render', () => {
+			const h = harness(() => (
+				<AccessibilityLinkButton linkProperties={{ to: 'outlet' }}>Some content</AccessibilityLinkButton>
+			));
+			h.expect(linkAssertion);
+		});
+
+		const allInAssertion = assertionTemplate(() => (
+			<Link
+				key="link"
+				disabled
+				classes={css.root}
+				routerKey="routerKey"
+				isOutlet
+				params={{ key: 'value' }}
+				onClick={() => {}}
+				to="outlet"
+			>
+				Some content
+			</Link>
+		));
+
+		it('should pass parameters to link and badge', () => {
+			const h = harness(() => (
+				<AccessibilityLinkButton
+					key="link"
+					disabled
+					linkProperties={{
+						to: 'outlet',
+						routerKey: 'routerKey',
+						isOutlet: true,
+						params: { key: 'value' },
+						onClick: () => {}
+					}}
+				>
+					Some content
+				</AccessibilityLinkButton>
+			));
+			h.expect(allInAssertion);
+		});
+	});
+
+	describe('External Link', () => {
+		const linkAssertion = assertionTemplate(() => (
+			<a key="undefined" disabled={false} classes={css.root} href="https://example.com">
+				Some content
+			</a>
+		));
+
+		it('should render', () => {
+			const h = harness(() => (
+				<AccessibilityLinkButton href="https://example.com">Some content</AccessibilityLinkButton>
+			));
+			h.expect(linkAssertion);
+		});
+
+		const allInAssertion = assertionTemplate(() => (
+			<a key="link" disabled classes={css.root} href="https://example.com">
+				Some content
+			</a>
+		));
+
+		it('should pass parameters to link and badge', () => {
+			const h = harness(() => (
+				<AccessibilityLinkButton key="link" disabled href="https://example.com">
+					Some content
+				</AccessibilityLinkButton>
+			));
+			h.expect(allInAssertion);
+		});
+	});
+
+	describe('Button', () => {
+		const buttonAssertion = assertionTemplate(() => (
+			<button key="button" disabled={false} onclick={() => {}} type="button" classes={css.root}>
+				Some content
+			</button>
+		));
+
+		it('should render', () => {
+			const h = harness(() => (
+				<AccessibilityLinkButton key="button" onClick={() => {}}>
+					Some content
+				</AccessibilityLinkButton>
+			));
+			h.expect(buttonAssertion);
+		});
+
+		const allInAssertion = assertionTemplate(() => (
+			<button key="button" disabled onclick={() => {}} type="button" classes={css.root}>
+				Some content
+			</button>
+		));
+
+		it('should pass parameters to link and badge', () => {
+			const onClick = jest.fn();
+			const h = harness(() => (
+				<AccessibilityLinkButton key="button" disabled onClick={onClick}>
+					Some content
+				</AccessibilityLinkButton>
+			));
+			h.expect(allInAssertion);
+
+			h.trigger('@button', 'onclick');
+
+			expect(onClick).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/widgets/accessibility-link-button/AccessibilityLinkButton.tsx
+++ b/src/widgets/accessibility-link-button/AccessibilityLinkButton.tsx
@@ -1,0 +1,50 @@
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import { tsx } from '@dojo/framework/core/vdom';
+import { LinkProperties } from '@dojo/framework/routing/interfaces';
+import Link from '@dojo/framework/routing/Link';
+
+import * as css from './AccessibilityLinkButton.m.css';
+
+export interface AccessibiltyLinkButtonProperties extends ThemedProperties {
+	onClick?: () => void;
+	disabled?: boolean;
+	linkProperties?: LinkProperties;
+	href?: string;
+}
+
+@theme(css)
+export class AccessibilityLinkButton extends ThemedMixin(WidgetBase)<AccessibiltyLinkButtonProperties> {
+	protected render() {
+		const { key, onClick, disabled = false, linkProperties, href } = this.properties;
+
+		if (href) {
+			return (
+				<a key={key} href={href} disabled={disabled} classes={this.theme(css.root)}>
+					{this.children}
+				</a>
+			);
+		}
+
+		if (linkProperties) {
+			return (
+				<Link
+					key={key ? `${key}` : undefined}
+					{...linkProperties}
+					disabled={disabled}
+					classes={this.theme(css.root)}
+				>
+					{this.children}
+				</Link>
+			);
+		}
+
+		return (
+			<button key={key} type="button" onclick={onClick} disabled={disabled} classes={this.theme(css.root)}>
+				{this.children}
+			</button>
+		);
+	}
+}
+
+export default AccessibilityLinkButton;

--- a/src/widgets/footer/Footer.m.css
+++ b/src/widgets/footer/Footer.m.css
@@ -8,6 +8,7 @@
 	background: var(--dark-background-color);
 	color: var(--color-white);
 	padding: var(--grid-size);
+	height: calc(var(--grid-size) * 2.4);
 }
 
 @media (max-width: 850px) {

--- a/src/widgets/header/Header.m.css
+++ b/src/widgets/header/Header.m.css
@@ -19,7 +19,8 @@
 
 .menu {
 	margin-right: var(--menu-offset);
-	overflow: hidden;
+	display: flex;
+	align-items: center;
 }
 
 .menuList {
@@ -184,13 +185,14 @@
 		margin: 0;
 		opacity: 0.95;
 		background: var(--responsive-header-background-color);
+		box-shadow: -8px 0 8px var(--shadow-color);
+		align-items: start;
+		flex-direction: column;
 	}
 
 	.menuList {
 		margin: 0;
 		padding: 2.5em 0 0;
-		box-shadow: -8px 0 8px var(--shadow-color);
-		min-height: 100%;
 		width: 70vw;
 		display: block;
 		padding: var(--grid-size) calc(var(--grid-size) * 2);

--- a/src/widgets/header/Header.tsx
+++ b/src/widgets/header/Header.tsx
@@ -2,17 +2,42 @@ import WidgetBase from '@dojo/framework/core/WidgetBase';
 import { tsx } from '@dojo/framework/core/vdom';
 import Link from '@dojo/framework/routing/ActiveLink';
 import Router from '@dojo/framework/routing/Router';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
 
 const logo = require('../../assets/logo.svg');
 
-import ReferenceGuideMenu from '../../pages/reference-guides/ReferenceGuideMenu';
+import { versions, currentVersion, outlets } from '../../constants';
+import { toSlug } from '../../util/to-slug';
 import SideMenuItemList from '../menu/SideMenuItemList';
 import SideMenuItem from '../menu/SideMenuItem';
-import { toSlug } from '../../util/to-slug';
+import PopupMenuButton from '../popup-menu-button/PopupMenuButton';
+import ReferenceGuideMenu from '../../pages/reference-guides/ReferenceGuideMenu';
 
 import * as css from './Header.m.css';
 
-const pages = ['Blog', 'Reference Guides', 'Examples', 'Playground', 'Roadmap', 'Community'];
+const pages = [
+	{
+		name: 'Blog',
+		requiresStable: true
+	},
+	{
+		name: 'Reference Guides'
+	},
+	{
+		name: 'Examples'
+	},
+	{
+		name: 'Playground'
+	},
+	{
+		name: 'Roadmap',
+		requiresStable: true
+	},
+	{
+		name: 'Community',
+		requiresStable: true
+	}
+];
 
 export default class Menu extends WidgetBase {
 	protected onAttach() {
@@ -26,6 +51,10 @@ export default class Menu extends WidgetBase {
 	}
 
 	protected render() {
+		const {
+			size: { width }
+		} = this.meta(Dimensions).get('root');
+
 		return (
 			<header key="root" classes={css.root}>
 				<input id="mainMenuToggle" classes={css.mainMenuToggle} type="checkbox" />
@@ -45,58 +74,107 @@ export default class Menu extends WidgetBase {
 				</div>
 				<nav role="navigation" classes={[css.menu]} aria-label="Main Menu">
 					<SideMenuItemList classes={{ 'dojo.io/SideMenuItemList': { root: [css.menuList] } }}>
-						{pages.map((page) => [
-							page === 'Reference Guides' && (
+						{pages.map((page) => {
+							let href: string | undefined;
+							// Check that the version of the docs is the lastest stable version. If so direct blog, roadmap and community to stable.
+							if (currentVersion.current && currentVersion.tag !== 'stable' && page.requiresStable) {
+								const hostname = window.location.hostname.split('.');
+								if (hostname.length > 2 || (hostname.length === 2 && hostname[1] === 'localhost')) {
+									hostname.shift();
+								}
+								href = `${window.location.protocol}//${hostname.join('.')}${
+									location.port ? `:${location.port}` : ''
+								}/${toSlug(page.name)}`;
+							}
+							return [
+								page.name === 'Reference Guides' && (
+									<SideMenuItem
+										name={page.name}
+										classes={{
+											'dojo.io/SideMenuItem': {
+												root: [css.menuItem, css.smallScreenOnly],
+												link: [css.link]
+											}
+										}}
+										inverse
+									>
+										<ReferenceGuideMenu
+											name="i18n"
+											route="reference-guide-i18n"
+											repo="dojo/framework"
+											path="docs/:locale:/i18n"
+											standaloneMenu={false}
+										/>
+										<ReferenceGuideMenu
+											name="Styling and Theming"
+											route="reference-guide-styling-and-theming"
+											repo="dojo/framework"
+											path="docs/:locale:/styling-and-theming"
+											standaloneMenu={false}
+										/>
+										<ReferenceGuideMenu
+											name="Routing"
+											route="reference-guide-routing"
+											repo="dojo/framework"
+											path="docs/:locale:/routing"
+											standaloneMenu={false}
+										/>
+									</SideMenuItem>
+								),
 								<SideMenuItem
-									name={page}
+									to={href || toSlug(page.name)}
 									classes={{
 										'dojo.io/SideMenuItem': {
-											root: [css.menuItem, css.smallScreenOnly],
+											root: [
+												css.menuItem,
+												page.name === 'Reference Guides' ? css.noSmallScreen : undefined
+											],
 											link: [css.link]
 										}
 									}}
 									inverse
 								>
-									<ReferenceGuideMenu
-										name="i18n"
-										route="reference-guide-i18n"
-										repo="dojo/framework"
-										path="docs/:locale:/i18n"
-										standaloneMenu={false}
-									/>
-									<ReferenceGuideMenu
-										name="Styling and Theming"
-										route="reference-guide-styling-and-theming"
-										repo="dojo/framework"
-										path="docs/:locale:/styling-and-theming"
-										standaloneMenu={false}
-									/>
-									<ReferenceGuideMenu
-										name="Routing"
-										route="reference-guide-routing"
-										repo="dojo/framework"
-										path="docs/:locale:/routing"
-										standaloneMenu={false}
-									/>
+									{page.name}
 								</SideMenuItem>
-							),
-							<SideMenuItem
-								to={toSlug(page)}
-								classes={{
-									'dojo.io/SideMenuItem': {
-										root: [
-											css.menuItem,
-											page === 'Reference Guides' ? css.noSmallScreen : undefined
-										],
-										link: [css.link]
-									}
-								}}
-								inverse
-							>
-								{page}
-							</SideMenuItem>
-						])}
+							];
+						})}
 					</SideMenuItemList>
+					<PopupMenuButton
+						position={width <= 768 ? 'top-left' : 'top-right'}
+						items={versions.map((version) => {
+							let href: string | undefined = undefined;
+							if (!version.current) {
+								const hostname = window.location.hostname.split('.');
+								if (hostname.length > 2 || (hostname.length === 2 && hostname[1] === 'localhost')) {
+									hostname.shift();
+								}
+
+								let subdomain = `${version.shortName}.`;
+								if (version.tag === 'stable') {
+									subdomain = '';
+								} else if (version.tag) {
+									subdomain = `${version.tag}.`;
+								}
+
+								href = `${window.location.protocol}//${subdomain}${hostname.join('.')}${
+									location.port ? `:${location.port}` : ''
+								}`;
+							}
+							return {
+								title: `${version.tag || version.shortName}${
+									version.current ? ` (${version.name})` : ''
+								}`,
+								href: href,
+								linkProperties: href
+									? undefined
+									: {
+											to: outlets.home
+									  }
+							};
+						})}
+					>
+						{`${currentVersion.tag || currentVersion.shortName} (${currentVersion.name})`}
+					</PopupMenuButton>
 				</nav>
 			</header>
 		);

--- a/src/widgets/menu/SideMenuItem.m.css
+++ b/src/widgets/menu/SideMenuItem.m.css
@@ -72,9 +72,6 @@
 	margin-left: auto;
 }
 
-.children {
-}
-
 .children.expanded {
 	visibility: visible;
 	opacity: 1;

--- a/src/widgets/menu/SideMenuItem.spec.tsx
+++ b/src/widgets/menu/SideMenuItem.spec.tsx
@@ -54,7 +54,7 @@ describe('Side Menu Item', () => {
 			const h = harness(() => <SideMenuItem to="https://example.com/">A link</SideMenuItem>);
 
 			const assertion = baseAssertion.setChildren('@menu-item', () => [
-				<a key="link" href="https://example.com/" target="_blank" classes={css.link}>
+				<a key="link" href="https://example.com/" classes={[css.link]}>
 					A link
 				</a>
 			]);

--- a/src/widgets/menu/SideMenuItem.tsx
+++ b/src/widgets/menu/SideMenuItem.tsx
@@ -63,7 +63,7 @@ export default class SideMenuItem extends ThemedMixin(WidgetBase)<SideMenuItemPr
 			<li key="menu-item" classes={this.theme(css.root)}>
 				{to ? (
 					/^https?:\/\/[\S]+$/g.test(to) ? (
-						<a key="link" href={to} target="_blank" classes={this.theme(css.link)}>
+						<a key="link" href={to} classes={this.theme(linkClasses)}>
 							{this.children}
 						</a>
 					) : (

--- a/src/widgets/popup-menu-button/PopupMenuButton.m.css
+++ b/src/widgets/popup-menu-button/PopupMenuButton.m.css
@@ -1,0 +1,20 @@
+@import '../../variables.css';
+
+.root {
+	display: flex;
+	position: relative;
+	margin-left: calc(var(--grid-size) * 2);
+}
+
+.button {
+	padding: 10px;
+	background: none;
+	color: var(--font-color-inverse);
+	border: 1px solid #6b6b6b;
+	text-transform: uppercase;
+}
+
+.button:hover {
+	color: var(--color-white);
+	border-color: #787878;
+}

--- a/src/widgets/popup-menu-button/PopupMenuButton.m.css.d.ts
+++ b/src/widgets/popup-menu-button/PopupMenuButton.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const button: string;

--- a/src/widgets/popup-menu-button/PopupMenuButton.spec.tsx
+++ b/src/widgets/popup-menu-button/PopupMenuButton.spec.tsx
@@ -1,0 +1,188 @@
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/core/vdom';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+
+import PopupMenu, { PopupMenuItem, PopupMenuPositioning } from '../popup-menu/PopupMenu';
+
+import { MockMetaMixin } from '../../test/util/MockMeta';
+
+import PopupMenuButton, { PopupMenuPosition } from './PopupMenuButton';
+import * as css from './PopupMenuButton.m.css';
+
+describe('PopupMenuButton', () => {
+	const noop = function() {};
+	let items: PopupMenuItem[];
+
+	let itemClick = jest.fn();
+	let MockPopupMenuButton: typeof PopupMenuButton;
+
+	const baseAssertion = assertionTemplate(() => (
+		<div classes={css.root}>
+			<div key="buttonWrapper">
+				<button classes={css.button} key="popupMenuButton" onclick={noop}>
+					Button
+				</button>
+			</div>
+		</div>
+	));
+
+	const popupMenu = (
+		position: PopupMenuPositioning = {
+			right: 0,
+			top: 24
+		}
+	) => (
+		<PopupMenu
+			key="popupMenu"
+			position={position}
+			onFocus={noop}
+			onBlur={noop}
+			items={[
+				{
+					title: 'foo',
+					onClick: () => {}
+				}
+			]}
+		/>
+	);
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+
+		const mockMetaMixin = new MockMetaMixin(PopupMenuButton);
+
+		mockMetaMixin.registerMetaCall(Dimensions, 'get', ['buttonWrapper'], {
+			size: {
+				width: 100,
+				height: 24
+			}
+		});
+
+		MockPopupMenuButton = mockMetaMixin.getClass();
+
+		itemClick = jest.fn();
+		items = [
+			{
+				title: 'foo',
+				onClick: itemClick
+			}
+		];
+	});
+
+	it('default renders correctly open', () => {
+		const h = harness(() => <MockPopupMenuButton items={[]}>Button</MockPopupMenuButton>);
+		h.expect(baseAssertion);
+	});
+
+	it('toggles on click', () => {
+		const h = harness(() => <MockPopupMenuButton items={items}>Button</MockPopupMenuButton>);
+
+		h.trigger('@popupMenuButton', 'onclick');
+
+		const assertion = baseAssertion.append(':root', () => [popupMenu()]);
+		h.expect(assertion);
+		h.trigger('@popupMenu', 'onFocus');
+
+		// Click should do nothing, but the removal of focus does
+		h.trigger('@popupMenuButton', 'onclick');
+
+		h.expect(assertion);
+
+		h.trigger('@popupMenu', 'onBlur');
+		h.expect(baseAssertion);
+
+		// Instally clicking again does not open the menu until after a 250ms timeout (after onBlur) to prevent the popup menu from flashing closed then opened
+		h.trigger('@popupMenuButton', 'onclick');
+		h.expect(baseAssertion);
+
+		jest.runAllTimers();
+
+		h.trigger('@popupMenuButton', 'onclick');
+		h.expect(assertion);
+	});
+
+	it('closes popup on blur', () => {
+		const h = harness(() => <MockPopupMenuButton items={items}>Button</MockPopupMenuButton>);
+
+		h.trigger('@popupMenuButton', 'onclick');
+		h.trigger('@popupMenu', 'onBlur');
+
+		h.expect(baseAssertion);
+	});
+
+	it('closes popup on menu item click', () => {
+		const h = harness(() => <MockPopupMenuButton items={items}>Button</MockPopupMenuButton>);
+
+		h.trigger('@popupMenuButton', 'onclick');
+		h.trigger('@popupMenu', (node) => {
+			return (node.properties as any).items[0].onClick;
+		});
+
+		expect(itemClick).toHaveBeenCalled();
+		h.expect(baseAssertion);
+	});
+
+	describe('positions', () => {
+		const testPosition = (positionName: PopupMenuPosition, position: PopupMenuPositioning) => {
+			const h = harness(() => (
+				<MockPopupMenuButton position={positionName} items={items}>
+					Button
+				</MockPopupMenuButton>
+			));
+
+			h.trigger('@popupMenuButton', 'onclick');
+
+			const assertion = baseAssertion.append(':root', () => [popupMenu(position)]);
+			h.expect(assertion);
+		};
+
+		test('top-left', () =>
+			testPosition('top-left', {
+				left: 0,
+				top: 24
+			}));
+
+		test('top-right', () =>
+			testPosition('top-right', {
+				right: 0,
+				top: 24
+			}));
+
+		test('left-top', () =>
+			testPosition('left-top', {
+				left: 100,
+				top: 0
+			}));
+
+		test('left-bottom', () =>
+			testPosition('left-bottom', {
+				left: 100,
+				bottom: 0
+			}));
+
+		test('right-top', () =>
+			testPosition('right-top', {
+				right: 100,
+				top: 0
+			}));
+
+		test('right-bottom', () =>
+			testPosition('right-bottom', {
+				right: 100,
+				bottom: 0
+			}));
+
+		test('bottom-left', () =>
+			testPosition('bottom-left', {
+				left: 0,
+				bottom: 24
+			}));
+
+		test('bottom-right', () =>
+			testPosition('bottom-right', {
+				right: 0,
+				bottom: 24
+			}));
+	});
+});

--- a/src/widgets/popup-menu-button/PopupMenuButton.tsx
+++ b/src/widgets/popup-menu-button/PopupMenuButton.tsx
@@ -1,0 +1,131 @@
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { theme, ThemedMixin } from '@dojo/framework/core/mixins/Themed';
+import { tsx } from '@dojo/framework/core/vdom';
+import watch from '@dojo/framework/core/decorators/watch';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+
+import PopupMenu, { PopupMenuPositioning, PopupMenuItem } from '../popup-menu/PopupMenu';
+
+import * as css from './PopupMenuButton.m.css';
+
+export type PopupMenuPosition =
+	| 'top-left'
+	| 'top-right'
+	| 'left-top'
+	| 'left-bottom'
+	| 'right-top'
+	| 'right-bottom'
+	| 'bottom-left'
+	| 'bottom-right';
+
+export interface PopupMenuButtonProperties {
+	items: PopupMenuItem[];
+	position?: PopupMenuPosition;
+}
+
+@theme(css)
+export default class PopupMenuButton extends ThemedMixin(WidgetBase)<PopupMenuButtonProperties> {
+	@watch() private open = false;
+	@watch() private hasFocus = false;
+	@watch() private hadFocus = false;
+	private onClick: Function | undefined = () => (this.open = true);
+
+	protected render() {
+		const { items, position = 'top-right' } = this.properties;
+
+		this.onClick = this.hadFocus ? undefined : () => (this.open = true);
+
+		const { size } = this.meta(Dimensions).get('buttonWrapper');
+
+		/**
+		 * Alignment to button
+		 *
+		 *       TL      TR
+		 *       __________
+		 *   LT |          | RT
+		 *      |  Popup   |
+		 *      |  Menu    |
+		 *   LB |__________| RB
+		 *       BL      BR
+		 */
+
+		const positioning: PopupMenuPositioning = {};
+		switch (position) {
+			case 'top-left': // TL
+				positioning.left = 0;
+				positioning.top = size.height;
+				break;
+			case 'top-right': // TR
+				positioning.right = 0;
+				positioning.top = size.height;
+				break;
+			case 'left-top': // LT
+				positioning.left = size.width;
+				positioning.top = 0;
+				break;
+			case 'left-bottom': // LB
+				positioning.left = size.width;
+				positioning.bottom = 0;
+				break;
+			case 'right-top': // RT
+				positioning.right = size.width;
+				positioning.top = 0;
+				break;
+			case 'right-bottom': // RB
+				positioning.right = size.width;
+				positioning.bottom = 0;
+				break;
+			case 'bottom-left': // BL
+				positioning.left = 0;
+				positioning.bottom = size.height;
+				break;
+			case 'bottom-right': // BR
+				positioning.right = 0;
+				positioning.bottom = size.height;
+				break;
+		}
+
+		if (!this.hasFocus && this.hadFocus) {
+			setTimeout(() => (this.hadFocus = false), 250); // Delay by 250ms to allow onclick event on the button to resolve first
+		}
+
+		return (
+			<div classes={this.theme(css.root)}>
+				<div key="buttonWrapper">
+					<button
+						key="popupMenuButton"
+						classes={this.theme(css.button)}
+						onclick={() => {
+							this.onClick && this.onClick();
+						}}
+					>
+						{this.children}
+					</button>
+				</div>
+				{this.open && (
+					<PopupMenu
+						key="popupMenu"
+						position={positioning}
+						onFocus={() => {
+							this.hasFocus = true;
+							this.hadFocus = true;
+						}}
+						onBlur={() => {
+							this.open = false;
+							this.hasFocus = false;
+						}}
+						items={items.map((item) => ({
+							...item,
+							onClick: () => {
+								item.onClick && item.onClick();
+								this.open = false;
+								this.hasFocus = false;
+								this.hadFocus = false;
+							}
+						}))}
+					/>
+				)}
+			</div>
+		);
+	}
+}

--- a/src/widgets/popup-menu/PopupMenu.m.css
+++ b/src/widgets/popup-menu/PopupMenu.m.css
@@ -1,0 +1,49 @@
+@import '../../variables.css';
+
+.root {
+	position: absolute;
+	outline: none;
+	box-shadow: var(--box-shadow-high-evelation);
+	width: calc(var(--grid-size) * 20);
+	background-color: var(--color-white);
+	z-index: var(--zindex-dropdown);
+	padding: var(--grid-size);
+	box-sizing: border-box;
+}
+
+.item {
+	text-transform: uppercase;
+	cursor: pointer;
+}
+
+.sectionHeader,
+.item {
+	white-space: nowrap;
+	padding: calc(var(--grid-size) / 2);
+	border-radius: 0;
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	text-align: left;
+}
+
+.item:not(:disabled):hover,
+.item:not(:disabled):hover:focus {
+	background-color: var(--color-off-white);
+	background-color: var(--color-surface);
+	text-decoration: none;
+	color: initial;
+}
+
+.item:not(:disabled):focus {
+	outline: none;
+	border-radius: 0;
+}
+
+.sectionHeader {
+	cursor: initial;
+}
+
+.item + .sectionHeader {
+	margin-top: var(--grid-size);
+}

--- a/src/widgets/popup-menu/PopupMenu.m.css.d.ts
+++ b/src/widgets/popup-menu/PopupMenu.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const item: string;
+export const sectionHeader: string;

--- a/src/widgets/popup-menu/PopupMenu.spec.tsx
+++ b/src/widgets/popup-menu/PopupMenu.spec.tsx
@@ -1,0 +1,251 @@
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/core/vdom';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import Focus from '@dojo/framework/core/meta/Focus';
+
+import AccessibilityLinkButton from '../accessibility-link-button/AccessibilityLinkButton';
+
+import { MockMetaMixin } from '../../test/util/MockMeta';
+
+import PopupMenu from './PopupMenu';
+import * as css from './PopupMenu.m.css';
+
+describe('PopupMenu', () => {
+	const noop = function() {};
+
+	const baseAssertionTemplate = assertionTemplate(() => (
+		<div
+			key="popupMenu"
+			classes={[css.root]}
+			tabindex="-1"
+			focus={true}
+			styles={{
+				top: undefined,
+				right: undefined,
+				left: undefined,
+				bottom: undefined
+			}}
+		/>
+	));
+
+	it('renders with a default position', () => {
+		const h = harness(() => <PopupMenu items={[]} />);
+		h.expect(baseAssertionTemplate);
+	});
+
+	it('renders with a specific position, and supports partial positions', () => {
+		const noPositionClass = baseAssertionTemplate.setProperty(':root', 'classes', [css.root]);
+
+		[
+			{
+				top: 100,
+				expected: { top: '100px', right: undefined, left: undefined, bottom: undefined }
+			},
+			{
+				right: 100,
+				expected: { top: undefined, right: '100px', left: undefined, bottom: undefined }
+			},
+			{
+				top: 200,
+				right: 200,
+				expected: { top: '200px', right: '200px', left: undefined, bottom: undefined }
+			},
+			{
+				top: 200,
+				left: 200,
+				expected: { top: '200px', right: undefined, left: '200px', bottom: undefined }
+			},
+			{
+				left: 100,
+				expected: { top: undefined, right: undefined, left: '100px', bottom: undefined }
+			},
+			{
+				bottom: 100,
+				expected: { top: undefined, right: undefined, left: undefined, bottom: '100px' }
+			},
+			{
+				left: 200,
+				bottom: 200,
+				expected: { top: undefined, right: undefined, left: '200px', bottom: '200px' }
+			},
+			{
+				right: 200,
+				bottom: 200,
+				expected: { top: undefined, right: '200px', left: undefined, bottom: '200px' }
+			}
+		].forEach(({ top, right, left, bottom, expected }) => {
+			const h = harness(() => <PopupMenu items={[]} position={{ top, right, left, bottom }} />);
+			h.expect(noPositionClass.setProperty(':root', 'styles', expected));
+		});
+	});
+
+	it('renders menu items', () => {
+		const h = harness(() => (
+			<PopupMenu
+				items={[
+					{
+						title: 'section',
+						sectionHeader: true
+					},
+					{
+						title: 'foo',
+						onClick: noop
+					},
+					{
+						title: <div>test</div>,
+						linkProperties: {
+							to: 'someOutlet'
+						}
+					}
+				]}
+			/>
+		));
+
+		const assertion = baseAssertionTemplate.setChildren(':root', () => [
+			<div classes={css.sectionHeader}>section</div>,
+			<AccessibilityLinkButton
+				classes={{ 'dojo.io/AccessibilityLinkButton': { root: [css.item] } }}
+				onClick={noop}
+				href={undefined}
+				linkProperties={undefined}
+			>
+				foo
+			</AccessibilityLinkButton>,
+			<AccessibilityLinkButton
+				classes={{ 'dojo.io/AccessibilityLinkButton': { root: [css.item] } }}
+				onClick={noop}
+				href={undefined}
+				linkProperties={{
+					to: 'someOutlet',
+					onClick: noop
+				}}
+			>
+				<div>test</div>
+			</AccessibilityLinkButton>
+		]);
+
+		h.expect(assertion);
+	});
+
+	it('clicks items', () => {
+		const onBlur = jest.fn();
+		const onButtonClick = jest.fn();
+		const onLinkClick = jest.fn();
+		const h = harness(() => (
+			<PopupMenu
+				onBlur={onBlur}
+				items={[
+					{
+						title: 'foo',
+						onClick: onButtonClick
+					},
+					{
+						title: <div>test</div>,
+						linkProperties: {
+							to: 'someOutlet',
+							onClick: onLinkClick
+						}
+					}
+				]}
+			/>
+		));
+
+		const assertion = baseAssertionTemplate.setChildren(':root', () => [
+			<AccessibilityLinkButton
+				classes={{ 'dojo.io/AccessibilityLinkButton': { root: [css.item] } }}
+				onClick={noop}
+				href={undefined}
+				linkProperties={undefined}
+			>
+				foo
+			</AccessibilityLinkButton>,
+			<AccessibilityLinkButton
+				classes={{ 'dojo.io/AccessibilityLinkButton': { root: [css.item] } }}
+				onClick={noop}
+				href={undefined}
+				linkProperties={{
+					to: 'someOutlet',
+					onClick: noop
+				}}
+			>
+				<div>test</div>
+			</AccessibilityLinkButton>
+		]);
+
+		h.expect(assertion);
+
+		h.trigger(':root', (node) => (node as any).children[0].properties.onClick);
+		expect(onButtonClick).toHaveBeenCalled();
+		h.expect(assertion);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+
+		h.trigger(':root', (node) => (node as any).children[1].properties.linkProperties.onClick);
+		expect(onLinkClick).toHaveBeenCalled();
+		h.expect(assertion);
+		expect(onBlur).toHaveBeenCalledTimes(2);
+	});
+
+	describe('focus', () => {
+		it('calls onFocus when menu in focus', () => {
+			const onFocus = jest.fn();
+
+			const mockMetaMixin = new MockMetaMixin(PopupMenu);
+
+			mockMetaMixin.registerMetaCallOnce(Focus, 'get', ['popupMenu'], {
+				active: false,
+				containsFocus: true
+			});
+
+			const MockPopupMenu = mockMetaMixin.getClass();
+
+			const h = harness(() => <MockPopupMenu items={[]} onFocus={onFocus} />);
+			h.expect(baseAssertionTemplate);
+
+			expect(onFocus).toHaveBeenCalled();
+		});
+
+		it('calls onBlur when menu goes out of focus', () => {
+			jest.useFakeTimers();
+			const onBlur = jest.fn();
+
+			const mockMetaMixin = new MockMetaMixin(PopupMenu);
+
+			mockMetaMixin.registerMetaCallOnce(
+				Focus,
+				'get',
+				['popupMenu'],
+				{
+					active: false,
+					containsFocus: true
+				},
+				{
+					value: {
+						active: false,
+						containsFocus: true
+					},
+					shouldInvalidate: true
+				},
+				{
+					value: {
+						active: false,
+						containsFocus: false
+					},
+					shouldInvalidate: true
+				}
+			);
+
+			const MockPopupMenu = mockMetaMixin.getClass();
+
+			const h = harness(() => <MockPopupMenu items={[]} onBlur={onBlur} />);
+			h.expect(baseAssertionTemplate);
+
+			jest.runAllTimers();
+			h.expect(baseAssertionTemplate);
+
+			jest.runAllTimers();
+			h.expect(baseAssertionTemplate);
+
+			expect(onBlur).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/widgets/popup-menu/PopupMenu.tsx
+++ b/src/widgets/popup-menu/PopupMenu.tsx
@@ -1,0 +1,109 @@
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
+import { tsx } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { LinkProperties } from '@dojo/framework/routing/interfaces';
+import watch from '@dojo/framework/core/decorators/watch';
+
+import AccessibilityLinkButton from '../accessibility-link-button/AccessibilityLinkButton';
+
+import * as css from './PopupMenu.m.css';
+
+export interface PopupMenuItem {
+	title: string | DNode;
+	sectionHeader?: boolean;
+	onClick?: () => void;
+	linkProperties?: LinkProperties;
+	href?: string;
+}
+
+export interface PopupMenuPositioning {
+	top?: number;
+	right?: number;
+	left?: number;
+	bottom?: number;
+}
+
+export interface PopupMenuProperties {
+	items: PopupMenuItem[];
+	position?: PopupMenuPositioning;
+	onFocus?: () => void;
+	onBlur?: () => void;
+}
+
+@theme(css)
+export default class PopupMenu extends ThemedMixin(WidgetBase)<PopupMenuProperties> {
+	private hasHadFocus = false;
+	@watch() private forceClose = false;
+
+	private onBlur() {
+		const { onBlur } = this.properties;
+		this.hasHadFocus = false;
+		onBlur && onBlur();
+	}
+
+	protected render(): DNode {
+		const { items, position = {}, onFocus } = this.properties;
+
+		const classes = [css.root];
+
+		let styles = {
+			top: typeof position.top !== 'undefined' ? `${position.top}px` : undefined,
+			right: typeof position.right !== 'undefined' ? `${position.right}px` : undefined,
+			left: typeof position.left !== 'undefined' ? `${position.left}px` : undefined,
+			bottom: typeof position.bottom !== 'undefined' ? `${position.bottom}px` : undefined
+		};
+
+		if (this.forceClose) {
+			this.forceClose = false;
+			this.onBlur();
+		} else {
+			const { active, containsFocus } = this.meta(Focus).get('popupMenu');
+			if (active || containsFocus) {
+				if (!this.hasHadFocus) {
+					onFocus && onFocus();
+				}
+				this.hasHadFocus = true;
+			} else if (this.hasHadFocus) {
+				this.onBlur();
+			}
+		}
+
+		return (
+			<div styles={styles} classes={this.theme(classes)} tabindex="-1" key="popupMenu" focus={true}>
+				{items.map((item: PopupMenuItem) => {
+					if (item.sectionHeader) {
+						return <div classes={this.theme(css.sectionHeader)}>{item.title}</div>;
+					}
+
+					if (item.linkProperties) {
+						const onClick = item.linkProperties.onClick;
+						item.linkProperties.onClick = (event) => {
+							onClick && onClick(event);
+							this.forceClose = true;
+						};
+					}
+
+					return (
+						<AccessibilityLinkButton
+							classes={{
+								'dojo.io/AccessibilityLinkButton': {
+									root: this.theme([css.item])
+								}
+							}}
+							onClick={() => {
+								item.onClick && item.onClick();
+								this.forceClose = true;
+							}}
+							linkProperties={item.linkProperties}
+							href={item.href}
+						>
+							{item.title}
+						</AccessibilityLinkButton>
+					);
+				})}
+			</div>
+		);
+	}
+}


### PR DESCRIPTION
## Description

<!-- Describe at a high level what the PR achieves -->
- Add version selector
  - Add `PopupMenu` and `PopupMenuButton` widgets.
  - Add `AccessibilityButton` widget to automatically render a `<a>`, `<Link>` or `<button>` based on the properties.
- Add `MockWindow` utility to help testing the version selector.

### Code

This PR touches:

- [ ] Content
- [ ] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [x] Tests are included?

### Screenshots

<!--Screenshots of the frontend changes -->
![image](https://user-images.githubusercontent.com/1388138/60837511-57b29b00-a196-11e9-8b3c-b78aa479b271.png)
![image](https://user-images.githubusercontent.com/1388138/60837533-6305c680-a196-11e9-81ad-e103ad3b274f.png)
![image](https://user-images.githubusercontent.com/1388138/60837584-7fa1fe80-a196-11e9-85d6-f957ace5cabf.png)
![image](https://user-images.githubusercontent.com/1388138/60837626-9c3e3680-a196-11e9-89be-0f597756e45f.png)