### PR TITLE
Remove intersection observer as not needed due to site being static

### DIFF
--- a/src/home/GetGoing.m.css
+++ b/src/home/GetGoing.m.css
@@ -138,10 +138,6 @@
 	}
 }
 
-.hide {
-	display: none;
-}
-
 .resultContent {
 	display: flex;
 	align-content: center;

--- a/src/home/GetGoing.m.css.d.ts
+++ b/src/home/GetGoing.m.css.d.ts
@@ -19,7 +19,6 @@ export const string: string;
 export const codeline: string;
 export const codeContainer: string;
 export const cli: string;
-export const hide: string;
 export const resultContent: string;
 export const result: string;
 export const check: string;

--- a/src/home/GetGoing.tsx
+++ b/src/home/GetGoing.tsx
@@ -1,19 +1,14 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
-import has from '@dojo/framework/core/has';
 import theme from '@dojo/framework/core/middleware/theme';
-import intersection from '@dojo/framework/core/middleware/intersection';
 
 import Card from '../card/Card';
 
 import * as css from './GetGoing.m.css';
 
-const factory = create({ theme, intersection });
+const factory = create({ theme });
 
-export default factory(function GetGoing({ middleware: { theme, intersection } }) {
+export default factory(function GetGoing({ middleware: { theme } }) {
 	const themedCss = theme.classes(css);
-	const { isIntersecting } = intersection.get('cli');
-
-	const play = isIntersecting || has('build-time-render');
 
 	return (
 		<section classes={[themedCss.root]}>
@@ -28,20 +23,20 @@ export default factory(function GetGoing({ middleware: { theme, intersection } }
 					classes={{ 'dojo.io/Card': { root: [themedCss.commands], content: [themedCss.commandsContent] } }}
 				>
 					<div classes={[themedCss.command]}>
-						<span classes={[themedCss.commandOne, play ? themedCss.commandOneAnimation : null]}>
+						<span classes={[themedCss.commandOne, themedCss.commandOneAnimation]}>
 							npm i @dojo/cli @dojo/cli-create-app -g
 						</span>
-						<span classes={[play ? themedCss.blinkOne : null]}>|</span>
+						<span classes={[themedCss.blinkOne]}>|</span>
 					</div>
 					<div classes={[themedCss.command]}>
-						<span classes={[themedCss.commandTwo, play ? themedCss.commandTwoAnimation : null]}>
+						<span classes={[themedCss.commandTwo, themedCss.commandTwoAnimation]}>
 							dojo create app --name hello-world
 						</span>
-						<span classes={[play ? themedCss.blinkTwo : null]}>|</span>
+						<span classes={[themedCss.blinkTwo]}>|</span>
 					</div>
 				</Card>
 				<div classes={[themedCss.codeContainer]}>
-					<Card dark classes={{ 'dojo.io/Card': { root: [play ? themedCss.code : themedCss.hide] } }}>
+					<Card dark classes={{ 'dojo.io/Card': { root: [themedCss.code] } }}>
 						<div classes={[themedCss.codeline]}>
 							<span classes={[themedCss.keyword]}>import </span>
 							<span classes={[themedCss.variable]}>renderer</span>
@@ -105,7 +100,7 @@ export default factory(function GetGoing({ middleware: { theme, intersection } }
 					<Card
 						classes={{
 							'dojo.io/Card': {
-								root: [play ? themedCss.result : themedCss.hide],
+								root: [themedCss.result],
 								content: [themedCss.resultContent]
 							}
 						}}


### PR DESCRIPTION
## Description

As the site is static we can remove the intersection observer.

### Code

This PR touches:

- [ ] Content
- [ ] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [ ] Tests are included?

### Screenshots

<!--Screenshots of the frontend changes -->
