### PR TITLE
Allow multi-repository guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,80 +198,23 @@ Coming soon.
 
 ### Reference Guide
 
-1. Reference Guides should be added to the repository of the referenced content (most likely `dojo/framework`). The reference guide should consist of the following 3 files:
+1. Reference Guides should be added to the repository of the referenced content (most likely `dojo/framework`). 
+    
+    The reference guide should consist of the following files:
 
 	- `introduction.md`
-	- `basic-usage.md`
 	- `supplemental.md`
 
-	Pages will be generated for the introduction and basic usage files, and one page for each top level header (`h1`) in the supplemental file.
-2. Add page paths (for introduction, basic usage and each top level header (`h1`) in supplemental) to the `.dojorc` file.
+    These files should appear in `docs/:locale:/guide-name/` in the repository.
 
-	**Example**:
-	> .dojo.rc
-	```json
-	"reference-guides/i18n/introduction",
-	"reference-guides/i18n/basic-usage",
-	"reference-guides/i18n/working-with-message-bundles",
-	"reference-guides/i18n/internationalizing-a-dojo-application",
-	"reference-guides/i18n/advanced-formatting-cldr",
-	"reference-guides/i18n/standalone-api",
-	```
-3. Add a route for the reference guide to `routes.ts`.
-	**Example**:
-	> src/routes.ts
-	```ts
-	{
-		path: 'reference-guides/i18n/{page}',
-		outlet: 'reference-guide-i18n'
-	}
-	```
-4. Add an outlet for the route to the `ReferenceGuides` widget.
-	**Example**:
-	> src/reference-guides/ReferenceGuides.tsx
-	```ts
-	<Outlet
-		key="reference-guide-i18n"
-		id="reference-guide-i18n"
-		renderer={(matchDetails) => {
-			const { page } = matchDetails.params;
-			return (
-				<ReferenceGuide
-					name="i18n"
-					repo="dojo/framework"
-					path="docs/:locale:/i18n"
-					route="reference-guide-i18n"
-					page={page}
-				/>
-			);
-		}}
-	/>
-	```
-5. Add a landing link to the `ReferenceGuidesLanding` widget in `src/pages`.
-	**Example**:
-	> src/ReferenceGuidesLanding.tsx
-	```ts
-	<LandingLink
-		title={messages.i18n}
-		icon="globe"
-		to="reference-guide-i18n"
-		params={{ page: 'introduction' }}
-	>
-		{messages.i18nDescription}
-	</LandingLink>
-	```
-6. Add a menu entry to the `Header` widget for use in the hamburger menu on mobile.
-	**Example**:
-	> src/header/Header.tsx
-	```
-	<ReferenceGuideMenu
-		name="i18n"
-		route="reference-guide-i18n"
-		repo="dojo/framework"
-		path="docs/:locale:/i18n"
-		standaloneMenu={false}
-	/>
-	```
+	Pages will be generated for the introduction and basic usage files, and one page for each top level header (`h1`) in the supplemental file.
+2. If a new repository will be used, add it to `sources` in  the `src/learn/Learn.tsx` file.
+3. Add the guide to the `guides` list in the `src/learn/Learn.tsx` file. Each guide has the following parameters:
+
+    - **name** - Used in navigation
+    - **directory** - (`Optional`) The name of the directory holding the guides. Defaults to `name.toLowerCase().replace(' ', '-')`
+    - **repo** - (`Optional`) GitHub repository where the guide is located. Defaults to `dojo/framework`
+    - **branch** - (`Optional`) Repository branch where the guide is located. Defaults to the latest framework branch.
 
 ### Roadmap Entry
 

--- a/src/footer/Footer.tsx
+++ b/src/footer/Footer.tsx
@@ -29,7 +29,7 @@ export default factory(function Footer({ middleware: { theme, i18n } }) {
 						<div classes={themedCss.linksRow}>
 							<div classes={themedCss.links}>
 								<div classes={themedCss.title}>{messages.docs}</div>
-								{guides.map((guide) => (
+								{guides.map(({ name: guide }) => (
 									<Link
 										to="learn"
 										classes={css.link}

--- a/src/footer/__tests__/Footer.spec.tsx
+++ b/src/footer/__tests__/Footer.spec.tsx
@@ -27,7 +27,7 @@ describe('Footer', () => {
 						<div classes={css.linksRow}>
 							<div classes={css.links}>
 								<div classes={css.title}>{messages.docs}</div>
-								{guides.map((guide) => (
+								{guides.map(({ name: guide }) => (
 									<Link
 										to="learn"
 										classes={css.link}

--- a/src/learn/Learn.tsx
+++ b/src/learn/Learn.tsx
@@ -10,32 +10,46 @@ import LearnSectionMenu from './LearnSectionMenu';
 
 import * as css from './Learn.m.css';
 
+interface Guide {
+	name: string;
+	directory?: string;
+	repo?: string;
+	branch?: string;
+}
+
 interface LearnProperties {
 	guideName: string;
 	pageName: string;
 	url?: string;
+	repo?: string;
+	branch?: string;
 }
 
 const factory = create({ theme, i18n }).properties<LearnProperties>();
 
-export const guides = [
-	'Overview',
-	'Creating Widgets',
-	'Middleware',
-	'Building',
-	'I18n',
-	'Styling',
-	'Stores',
-	'Routing',
-	'Testing'
+export const sources = {
+	framework: {
+		repo: 'dojo/framework',
+		branch: 'v6'
+	}
+};
+
+export const guides: Guide[] = [
+	{ name: 'Overview' },
+	{ name: 'Creating Widgets' },
+	{ name: 'Middleware' },
+	{ name: 'Building' },
+	{ name: 'I18n' },
+	{ name: 'Styling' },
+	{ name: 'Stores' },
+	{ name: 'Routing' },
+	{ name: 'Testing' }
 ];
 
 export default factory(function Learn({ properties, middleware: { theme, i18n } }) {
-	const { guideName, pageName, url } = properties();
+	const { guideName, pageName, url, repo = sources.framework.repo, branch = sources.framework.branch } = properties();
 	const themedCss = theme.classes(css);
 	const path = `docs/:locale:/${guideName === 'overview' ? 'outline' : guideName.toLowerCase()}`;
-	const repo = 'dojo/framework';
-	const branch = 'v6';
 
 	let language = 'en';
 	let locale = 'en';
@@ -50,16 +64,28 @@ export default factory(function Learn({ properties, middleware: { theme, i18n } 
 			<nav classes={themedCss.nav}>
 				<ul classes={themedCss.menuList}>
 					{guides.map((guide) => {
+						const {
+							name,
+							directory,
+							repo = sources.framework.repo,
+							branch = sources.framework.branch
+						} = guide;
+
 						return (
 							<li classes={themedCss.menuItem}>
 								<Link
 									to="learn"
 									classes={css.menuLink}
-									params={{ guide: guide.toLowerCase().replace(' ', '-'), page: 'introduction' }}
-									matchParams={{ guide: guide.toLowerCase().replace(' ', '-') }}
+									params={{
+										guide: directory || name.toLowerCase().replace(' ', '-'),
+										page: 'introduction',
+										repo,
+										branch
+									}}
+									matchParams={{ guide: directory || name.toLowerCase().replace(' ', '-') }}
 									activeClasses={[css.selected]}
 								>
-									{guide}
+									{name}
 								</Link>
 							</li>
 						);

--- a/src/learn/_tests_/Learn.spec.tsx
+++ b/src/learn/_tests_/Learn.spec.tsx
@@ -9,20 +9,25 @@ import createI18nMock from '../../test/mockI18n';
 import LearnContent from '../LearnContent';
 import LearnSectionMenu from '../LearnSectionMenu';
 import * as css from '../Learn.m.css';
-import Learn, { guides } from '../Learn';
+import Learn, { guides, sources } from '../Learn';
 
 describe('Learn', () => {
 	const baseAssertion = assertionTemplate(() => (
 		<div classes={css.root}>
 			<nav classes={css.nav}>
 				<ul classes={css.menuList}>
-					{guides.map((guide) => {
+					{guides.map(({ name: guide }) => {
 						return (
 							<li classes={css.menuItem}>
 								<Link
 									to="learn"
 									classes={css.menuLink}
-									params={{ guide: guide.toLowerCase().replace(' ', '-'), page: 'introduction' }}
+									params={{
+										guide: guide.toLowerCase().replace(' ', '-'),
+										page: 'introduction',
+										repo: sources.framework.repo,
+										branch: sources.framework.branch
+									}}
 									matchParams={{ guide: guide.toLowerCase().replace(' ', '-') }}
 									activeClasses={[css.selected]}
 								>


### PR DESCRIPTION
## Description

Refactors `guides` list in `src/learn/Learn.tsx` from `string[]` to `{ name: string }[]`

- Adds optional `directory` property (Defaults to `name.toLowerCase().replace(' ', '-')`)
- Adds optional `repo` property
- Adds optional `branch` property

README is updated to reflect the new `guides` definition.

### Code

This PR touches:

- [x] Content
- [x] Content Pipeline
- [ ] Frontend
- [ ] Infrastructure

### Tests

- [ ] Tests are included?

Fixes #194 