### PR TITLE
Add dojo widgets top menu item

### DIFF
--- a/src/header/Header.nls.ts
+++ b/src/header/Header.nls.ts
@@ -1,0 +1,5 @@
+const messages = {
+	widgets: 'Widgets'
+};
+
+export default { messages };

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -1,17 +1,21 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
+import i18n from '@dojo/framework/core/middleware/i18n';
 import theme from '@dojo/framework/core/middleware/theme';
 import icache from '@dojo/framework/core/middleware/icache';
+
 import Link from '../link/ActiveLink';
 
 const logo = require('../assets/logo.svg');
 
 import * as css from './Header.m.css';
+import bundle from './Header.nls';
 
 const menuItems = ['Blog', 'Learn', 'Playground', 'Roadmap'];
 
-const factory = create({ theme, icache });
+const factory = create({ theme, icache, i18n });
 
-export default factory(function Header({ middleware: { theme, icache } }) {
+export default factory(function Header({ middleware: { theme, icache, i18n } }) {
+	const { messages } = i18n.localize(bundle);
 	const themedCss = theme.classes(css);
 	const open = icache.get<boolean>('open') || false;
 
@@ -74,6 +78,11 @@ export default factory(function Header({ middleware: { theme, icache } }) {
 							</li>
 						);
 					})}
+					<li classes={[themedCss.menuItem]}>
+						<a classes={themedCss.menuLink} target="_blank" href="https://widgets.dojo.io">
+							{messages.widgets}
+						</a>
+					</li>
 				</ul>
 			</nav>
 			<a

--- a/src/header/__tests__/Header.spec.tsx
+++ b/src/header/__tests__/Header.spec.tsx
@@ -7,6 +7,9 @@ const logo = require('../../assets/logo.svg');
 
 import * as css from '../Header.m.css';
 import Header from '../Header';
+import bundle from '../Header.nls';
+
+const messages = bundle.messages;
 
 describe('Header', () => {
 	const noop = () => {};
@@ -87,6 +90,11 @@ describe('Header', () => {
 						>
 							Roadmap
 						</Link>
+					</li>
+					<li classes={[css.menuItem]}>
+						<a classes={css.menuLink} target="_blank" href="https://widgets.dojo.io">
+							{messages.widgets}
+						</a>
 					</li>
 				</ul>
 			</nav>


### PR DESCRIPTION
## Description

Add link to widgets.dojo.io, set to open in a new tab.

Resolves #174 

### Code

This PR touches:

- [ ] Content
- [ ] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [x] Tests are included?

### Screenshots

<!--Screenshots of the frontend changes -->
![image](https://user-images.githubusercontent.com/1388138/77114011-30d58580-6a02-11ea-9ee0-1e390a929505.png)
