### PR TITLE
Feature/v6 domain change

### DIFF
--- a/src/footer/Footer.tsx
+++ b/src/footer/Footer.tsx
@@ -229,6 +229,15 @@ export default factory(function Footer({ middleware: { theme, i18n } }) {
 									<a
 										target="_blank"
 										rel="noopener noreferrer"
+										href="https://dojo.io"
+										classes={css.link}
+									>
+										Current
+										<img classes={themedCss.externalLink} alt="externalLink" src={externalLink} />
+									</a>
+									<a
+										target="_blank"
+										rel="noopener noreferrer"
 										href="https://v5.dojo.io"
 										classes={css.link}
 									>
@@ -236,10 +245,10 @@ export default factory(function Footer({ middleware: { theme, i18n } }) {
 										<img classes={themedCss.externalLink} alt="externalLink" src={externalLink} />
 									</a>
 									<div classes={themedCss.title}>{messages.languages}</div>
-									<a href="https://dojo.io" classes={css.link}>
+									<a href="https://v6.dojo.io" classes={css.link}>
 										{messages.english}
 									</a>
-									<a href="https://zh-CN.dojo.io" classes={css.link}>
+									<a href="https://zh-CN.v6.dojo.io" classes={css.link}>
 										{messages.simplifiedChinese}
 									</a>
 								</div>

--- a/src/footer/Footer.tsx
+++ b/src/footer/Footer.tsx
@@ -232,7 +232,7 @@ export default factory(function Footer({ middleware: { theme, i18n } }) {
 										href="https://dojo.io"
 										classes={css.link}
 									>
-										Current
+										Latest
 										<img classes={themedCss.externalLink} alt="externalLink" src={externalLink} />
 									</a>
 									<a

--- a/src/footer/__tests__/Footer.spec.tsx
+++ b/src/footer/__tests__/Footer.spec.tsx
@@ -227,6 +227,15 @@ describe('Footer', () => {
 									<a
 										target="_blank"
 										rel="noopener noreferrer"
+										href="https://dojo.io"
+										classes={css.link}
+									>
+										Latest
+										<img classes={css.externalLink} alt="externalLink" src={externalLink} />
+									</a>
+									<a
+										target="_blank"
+										rel="noopener noreferrer"
 										href="https://v5.dojo.io"
 										classes={css.link}
 									>
@@ -234,10 +243,10 @@ describe('Footer', () => {
 										<img classes={css.externalLink} alt="externalLink" src={externalLink} />
 									</a>
 									<div classes={css.title}>{messages.languages}</div>
-									<a href="https://dojo.io" classes={css.link}>
+									<a href="https://v6.dojo.io" classes={css.link}>
 										{messages.english}
 									</a>
-									<a href="https://zh-CN.dojo.io" classes={css.link}>
+									<a href="https://zh-CN.v6.dojo.io" classes={css.link}>
 										{messages.simplifiedChinese}
 									</a>
 								</div>


### PR DESCRIPTION
## Description

Update footer links to point to `v6` domains and add `Current` link to point back to main `dojo.io` site.

### Code

This PR touches:

- [ ] Content
- [ ] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [ ] Tests are included?