### PR TITLE
Stop pre-caching the index and let the routes deal with caching the index pages

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -33,6 +33,9 @@
 			},
 			"serviceWorker": {
 				"clientsClaim": true,
+				"precache": {
+					"index": "fake.html"
+				},
 				"routes": [
 					{
 						"urlPattern": ".*",


### PR DESCRIPTION
## Description

Prevent the service worker from serving a stale index by using the routes config and using network first.

### Code

This PR touches:

- [ ] Content
- [ ] Content Pipeline
- [x] Frontend
- [ ] Infrastructure

### Tests

- [ ] Tests are included?

### Screenshots

N/A

<!--Screenshots of the frontend changes -->
