### PR TITLE
Do not display headings svg on blogs

### DIFF
--- a/src/blog/__tests__/post.block.spec.ts
+++ b/src/blog/__tests__/post.block.spec.ts
@@ -21,44 +21,16 @@ const top = () =>
 		'h2',
 		{
 			id: 'blog-title-1',
-			key: 'compiled-6'
+			key: 'compiled-3'
 		},
-		[
-			v(
-				'a',
-				{
-					key: 'compiled-5',
-					'aria-hidden': 'true',
-					href: '#blog-title-1'
-				},
-				[
-					v(
-						'svg',
-						{
-							classes: 'refguide-link',
-							height: '16',
-							key: 'compiled-4',
-							width: '16'
-						},
-						[
-							v('path', {
-								d:
-									'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z',
-								key: 'compiled-3'
-							})
-						]
-					)
-				]
-			),
-			'Blog Title 1'
-		]
+		['Blog Title 1']
 	);
 
 const content = () =>
 	v(
 		'p',
 		{
-			key: 'compiled-7'
+			key: 'compiled-4'
 		},
 		['Content!']
 	);
@@ -75,7 +47,7 @@ const expectedOutput = {
 	content: v(
 		'section',
 		{
-			key: 'compiled-8'
+			key: 'compiled-5'
 		},
 		[top(), content()]
 	),
@@ -86,7 +58,7 @@ const expectedExcerptOutput = {
 	content: v(
 		'section',
 		{
-			key: 'compiled-7'
+			key: 'compiled-4'
 		},
 		[top()]
 	),

--- a/src/blog/post.block.ts
+++ b/src/blog/post.block.ts
@@ -20,7 +20,7 @@ export default async function(options: CompileBlogPost) {
 	let rawContent = await readFile(contentPath, 'utf-8');
 	rawContent = options.excerpt ? rawContent.split('<!-- more -->')[0] : rawContent;
 
-	const content = markdown(rawContent);
+	const content = markdown(rawContent, false);
 	const meta = metadata(rawContent);
 	return { content, meta };
 }

--- a/src/blog/rss.ts
+++ b/src/blog/rss.ts
@@ -47,8 +47,8 @@ export function createBlogFeed(files: BlogFile[], languageFolder: string) {
 			continue;
 		}
 
-		const fullContent = markdown(file.content, 'string') as string;
-		const description = markdown(file.content.split('<!-- more -->')[0], 'string') as string;
+		const fullContent = markdown(file.content, true, 'string') as string;
+		const description = markdown(file.content.split('<!-- more -->')[0], true, 'string') as string;
 
 		const url = `https://dojo.io/blog/${file.file.replace(`blog/${languageFolder}/`, '').replace('.md', '')}`;
 		const item = {

--- a/src/common/__tests__/markdown.spec.ts
+++ b/src/common/__tests__/markdown.spec.ts
@@ -159,7 +159,7 @@ describe('content compiler', () => {
 	});
 
 	it('should convert to string instead of DNodes', async () => {
-		const output = markdown(mockMarkupContent, 'string');
+		const output = markdown(mockMarkupContent, true, 'string');
 
 		expect(output).toEqual(mockMarkupStringOutput);
 	});

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -111,35 +111,39 @@ function clean(node: any) {
 	}
 }
 
-export const markdown = (content: string, outputType: 'dnode' | 'string' = 'dnode'): DNode => {
+export const markdown = (content: string, renderHeadings = true, outputType: 'dnode' | 'string' = 'dnode'): DNode => {
 	const pipeline = unified()
 		.use(remarkParse, { commonmark: true })
 
 		.use(frontmatter, 'yaml')
 		.use(macro.transformer)
-		.use(slug)
-		.use(headings, {
-			content: {
-				type: 'element',
-				tagName: 'svg',
-				properties: {
-					classes: 'refguide-link',
-					width: '16',
-					height: '16'
-				},
-				children: [
-					{
-						type: 'element',
-						tagName: 'path',
-						properties: {
-							d:
-								'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'
+		.use(slug);
+
+		if (renderHeadings) {
+			pipeline.use(headings, {
+				content: {
+					type: 'element',
+					tagName: 'svg',
+					properties: {
+						classes: 'refguide-link',
+						width: '16',
+						height: '16'
+					},
+					children: [
+						{
+							type: 'element',
+							tagName: 'path',
+							properties: {
+								d:
+									'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'
+							}
 						}
-					}
-				]
-			}
-		})
-		.use(section)
+					]
+				}
+			})
+		}
+
+		pipeline.use(section)
 		.use(remark2rehype, { handlers: registeredHandlers })
 		.use(() => (tree: any) => visit(tree, 'element', clean))
 		.use(rehypePrism, { ignoreMissing: false });

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -119,31 +119,32 @@ export const markdown = (content: string, renderHeadings = true, outputType: 'dn
 		.use(macro.transformer)
 		.use(slug);
 
-		if (renderHeadings) {
-			pipeline.use(headings, {
-				content: {
-					type: 'element',
-					tagName: 'svg',
-					properties: {
-						classes: 'refguide-link',
-						width: '16',
-						height: '16'
-					},
-					children: [
-						{
-							type: 'element',
-							tagName: 'path',
-							properties: {
-								d:
-									'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'
-							}
+	if (renderHeadings) {
+		pipeline.use(headings, {
+			content: {
+				type: 'element',
+				tagName: 'svg',
+				properties: {
+					classes: 'refguide-link',
+					width: '16',
+					height: '16'
+				},
+				children: [
+					{
+						type: 'element',
+						tagName: 'path',
+						properties: {
+							d:
+								'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'
 						}
-					]
-				}
-			})
-		}
+					}
+				]
+			}
+		});
+	}
 
-		pipeline.use(section)
+	pipeline
+		.use(section)
 		.use(remark2rehype, { handlers: registeredHandlers })
 		.use(() => (tree: any) => visit(tree, 'element', clean))
 		.use(rehypePrism, { ignoreMissing: false });


### PR DESCRIPTION
## Description

The heading svg is not required really on blogs, this adds an option to the markdown parser to skip them.

### Code

This PR touches:

- [ ] Content
- [x] Content Pipeline
- [ ] Frontend
- [ ] Infrastructure

### Tests

- [ ] Tests are included?

### Screenshots

<!--Screenshots of the frontend changes -->
